### PR TITLE
fix: 修复多平台查询崩溃与解析健壮性，收藏夹改用 JSON 存储

### DIFF
--- a/lib/services/rating_services.dart
+++ b/lib/services/rating_services.dart
@@ -3,19 +3,27 @@ import 'package:oj_helper/models/rating.dart' show Rating;
 import 'package:html/parser.dart' show parse;
 
 class RatingService {
-  final Dio dio = Dio();
+  final Dio dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
 
   ///获取codeforces的curRating,maxRating
   Future<Rating> getCodeforcesRating({name = ''}) async {
     final url =
         "https://codeforces.com/api/user.info?handles=$name&checkHistoricHandles=false";
     Response response = await dio.get(url);
-    if (response.statusCode == 200) {
-      final rating = response.data['result'][0]['rating'];
-      final maxRating = response.data['result'][0]['maxRating'];
+    // 用户不存在时 API 返回 status=FAILED 且 result 为错误信息字符串；
+    // 新账号可能没有 rating/maxRating（为 null），统一按 0 处理
+    if (response.statusCode == 200 &&
+        response.data['status'] == 'OK' &&
+        (response.data['result'] as List).isNotEmpty) {
+      final result = response.data['result'][0];
+      final rating = (result['rating'] ?? 0) as int;
+      final maxRating = (result['maxRating'] ?? 0) as int;
       return Rating(name: name, curRating: rating, maxRating: maxRating);
     } else {
-      throw Exception("请求失败，状态码：${response.statusCode}");
+      throw Exception("请求失败或用户不存在");
     }
   }
 
@@ -25,13 +33,25 @@ class RatingService {
     Response response = await dio.get(url);
     if (response.statusCode == 200) {
       final document = parse(response.data);
-      final rating = document
-          .getElementsByClassName('dl-table mt-2')[0]
-          .getElementsByTagName('tr');
+      final tables = document.getElementsByClassName('dl-table mt-2');
+      if (tables.isEmpty) {
+        throw Exception('无法解析 AtCoder 页面（页面可能改版或用户不存在）');
+      }
+      final rating = tables[0].getElementsByTagName('tr');
+      if (rating.length < 3) {
+        throw Exception('无法解析 AtCoder rating 数据');
+      }
+      // 未参赛用户页面显示 '-'，int.parse 会抛 FormatException，先做防御
+      int parseRating(int index) {
+        final spans = rating[index].getElementsByTagName('span');
+        final text = spans.isEmpty ? '-' : spans[0].text.trim();
+        if (text.isEmpty || text == '-') {
+          throw Exception('该用户暂无 rating');
+        }
+        return int.parse(text);
+      }
       return Rating(
-          name: name,
-          curRating: int.parse(rating[1].getElementsByTagName('span')[0].text),
-          maxRating: int.parse(rating[2].getElementsByTagName('span')[0].text));
+          name: name, curRating: parseRating(1), maxRating: parseRating(2));
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -97,19 +117,27 @@ class RatingService {
     );
     int userId;
     Response response = await dio.get(baseUrl, options: options);
-    if (response.statusCode == 200) {
-      userId = response.data['users'][0]['uid'];
-    } else {
+    if (response.statusCode != 200) {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
+    final users = response.data?['users'];
+    if (users is! List || users.isEmpty) {
+      throw Exception('未找到该洛谷用户，请检查用户名');
+    }
+    userId = users[0]['uid'];
     final url =
         'https://www.luogu.com.cn/api/rating/elo?user=$userId&page=1&limit=100';
     response = await dio.get(url, options: options);
     if (response.statusCode == 200) {
-      final curRating = response.data['records']['result'][0]['rating'];
+      final records = response.data?['records']?['result'];
+      if (records is! List || records.isEmpty) {
+        throw Exception('该用户暂无 rating 记录');
+      }
+      final curRating = (records[0]['rating'] ?? 0) as int;
       int maxRating = 0;
-      for (var i in response.data['records']['result']) {
-        maxRating = i['rating'] > maxRating ? i['rating'] : maxRating;
+      for (final i in records) {
+        final r = (i['rating'] ?? 0) as int;
+        maxRating = r > maxRating ? r : maxRating;
       }
       return Rating(name: name, curRating: curRating, maxRating: maxRating);
     } else {
@@ -122,25 +150,21 @@ class RatingService {
     final url = 'https://ac.nowcoder.com/acm/contest/rating-history?uid=$name';
     Response response = await dio.get(url);
     if (response.statusCode == 200) {
-      final rateHistory = response.data['data'];
-      final curRating = rateHistory.last['rating'].toInt();
+      final rateHistory = response.data?['data'];
+      if (rateHistory is! List || rateHistory.isEmpty) {
+        throw Exception('该用户暂无 rating 记录');
+      }
+      int toRating(dynamic v) => (v is num) ? v.toInt() : 0;
+      final curRating = toRating(rateHistory.last['rating']);
       //获取rateHisory的最大rating
       int maxRating = 0;
       for (var i in rateHistory) {
-        maxRating =
-            i['rating'].toInt() > maxRating ? i['rating'].toInt() : maxRating;
+        final r = toRating(i['rating']);
+        maxRating = r > maxRating ? r : maxRating;
       }
       return Rating(name: name, curRating: curRating, maxRating: maxRating);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
-  }
-}
-
-void main() async {
-  RatingService rs = RatingService();
-  var tmp = await rs.getLeetCodeRating(name: 'lu-ming-b');
-  for (var i in tmp) {
-    print("${i.name} ${i.curRating} ${i.maxRating} ${i.time} ${i.ranking}");
   }
 }

--- a/lib/services/rating_services.dart
+++ b/lib/services/rating_services.dart
@@ -121,6 +121,7 @@ class RatingService {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
     final users = response.data?['users'];
+    // 搜索无结果时 users 为空数组，直接取 [0] 会越界崩溃，先做防御
     if (users is! List || users.isEmpty) {
       throw Exception('未找到该洛谷用户，请检查用户名');
     }
@@ -151,6 +152,7 @@ class RatingService {
     Response response = await dio.get(url);
     if (response.statusCode == 200) {
       final rateHistory = response.data?['data'];
+      // 未参赛用户没有 rating 历史（空列表），取 .last 会越界；rating 也可能为 null
       if (rateHistory is! List || rateHistory.isEmpty) {
         throw Exception('该用户暂无 rating 记录');
       }
@@ -166,5 +168,14 @@ class RatingService {
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
+  }
+}
+
+/// 调试入口：本地验证各平台解析逻辑（保留，便于后续开发时单独运行）
+void main() async {
+  RatingService rs = RatingService();
+  var tmp = await rs.getLeetCodeRating(name: 'lu-ming-b');
+  for (var i in tmp) {
+    print("${i.name} ${i.curRating} ${i.maxRating} ${i.time} ${i.ranking}");
   }
 }

--- a/lib/services/solved_num_services.dart
+++ b/lib/services/solved_num_services.dart
@@ -4,7 +4,10 @@ import 'package:html/parser.dart' show parse;
 import 'package:oj_helper/models/solved_num.dart' show SolvedNum;
 
 class SolvedNumServices {
-  final dio = Dio();
+  final dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
 
   /// 获取codeforces的解题数
   ///   //数据来源：https://github.com/Liu233w/acm-statistics
@@ -12,7 +15,11 @@ class SolvedNumServices {
     final url = 'https://ojhunt.com/api/crawlers/codeforces/$name';
     final response = await dio.get(url);
     if (response.statusCode == 200) {
-      return SolvedNum(name: name, solvedNum: response.data['data']['solved']);
+      final data = response.data?['data'];
+      if (data == null || data['solved'] == null) {
+        throw Exception('查询失败或用户不存在');
+      }
+      return SolvedNum(name: name, solvedNum: data['solved'] as int);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -37,12 +44,16 @@ class SolvedNumServices {
     };
     Response response = await dio.post(url, data: data);
     if (response.statusCode == 200) {
-      final infor = response.data['data']['userProfileUserQuestionProgressV2']
-          ['numAcceptedQuestions'];
-      final easySolvedNum = infor[0]['count'];
-      final mediumSolvedNum = infor[1]['count'];
-      final hardSolvedNum = infor[2]['count'];
-      final totalSolvedNum = easySolvedNum + mediumSolvedNum + hardSolvedNum;
+      final progress = response.data?['data']
+          ?['userProfileUserQuestionProgressV2'];
+      final infor = progress?['numAcceptedQuestions'];
+      // 新用户可能没有做题记录（数组为空或字段缺失），按 0 处理
+      int totalSolvedNum = 0;
+      if (infor is List) {
+        for (final item in infor) {
+          totalSolvedNum += (item?['count'] as int? ?? 0);
+        }
+      }
       return SolvedNum(name: name, solvedNum: totalSolvedNum);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
@@ -62,8 +73,11 @@ class SolvedNumServices {
         final jsonData = match.group(1);
         if (jsonData != null) {
           final data = json.decode(jsonData);
-          final solvedNum = data['counts']['acAll'] as int;
-          return SolvedNum(name: name, solvedNum: solvedNum);
+          final acAll = data?['counts']?['acAll'];
+          if (acAll is num) {
+            return SolvedNum(name: name, solvedNum: acAll.toInt());
+          }
+          throw Exception('无法解析Vjudge数据');
         }
       }
       throw Exception('无法解析Vjudge数据');
@@ -82,16 +96,23 @@ class SolvedNumServices {
     );
     final response = await dio.get(url, options: options);
     if (response.statusCode == 200) {
-      print(response.data);
-      int userId = response.data['users'][0]['uid'];
+      final users = response.data?['users'];
+      if (users is! List || users.isEmpty) {
+        throw Exception('未找到该洛谷用户，请检查用户名');
+      }
+      int userId = users[0]['uid'];
       final url = 'https://www.luogu.com.cn/user/$userId';
       final res = await dio.get(url, options: options);
       if (res.statusCode == 200) {
-        final text = res.data
-            .toString()
-            .split('passedProblemCount')[1]
-            .split('submittedProblemCount')[0];
-        String decodedString = Uri.decodeComponent(text);
+        final parts = res.data.toString().split('passedProblemCount');
+        if (parts.length < 2) {
+          throw Exception('无法解析洛谷数据');
+        }
+        final subParts = parts[1].split('submittedProblemCount');
+        String decodedString = Uri.decodeComponent(subParts[0]);
+        if (decodedString.length < 4) {
+          throw Exception('无法解析洛谷数据');
+        }
         decodedString = decodedString.substring(2, decodedString.length - 2);
         final solvedNum = int.parse(decodedString);
         return SolvedNum(name: name, solvedNum: solvedNum);
@@ -123,7 +144,11 @@ class SolvedNumServices {
     final url = 'https://ojhunt.com/api/crawlers/hdu/$name';
     final response = await dio.get(url);
     if (response.statusCode == 200) {
-      return SolvedNum(name: name, solvedNum: response.data['data']['solved']);
+      final data = response.data?['data'];
+      if (data == null || data['solved'] == null) {
+        throw Exception('查询失败或用户不存在');
+      }
+      return SolvedNum(name: name, solvedNum: data['solved'] as int);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -153,7 +178,11 @@ class SolvedNumServices {
     final url = 'https://ojhunt.com/api/crawlers/nowcoder/$name';
     final response = await dio.get(url);
     if (response.statusCode == 200) {
-      return SolvedNum(name: name, solvedNum: response.data['data']['solved']);
+      final data = response.data?['data'];
+      if (data == null || data['solved'] == null) {
+        throw Exception('查询失败或用户不存在');
+      }
+      return SolvedNum(name: name, solvedNum: data['solved'] as int);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -251,8 +280,15 @@ class SolvedNumServices {
     try {
       var start = 0;
       var limit = 25;
+      var pageCount = 0;
+      // 避免用户不存在时无限遍历整个排行榜
+      final maxPages = 2000;
 
       while (true) {
+        pageCount++;
+        if (pageCount > maxPages) {
+          throw Exception("未找到用户（已超过查询上限）");
+        }
         final url = 'https://www.matiji.net/exam-back/pc/ojRankByType.do';
         final response = await dio.post(
           url,
@@ -266,16 +302,22 @@ class SolvedNumServices {
 
         if (response.statusCode == 200) {
           final data = response.data;
-          if (data['error_no'] == '0') {
-            final datas = data['data']['datas'] as List;
+          // error_no 可能以字符串或数字形式返回，统一转字符串比较
+          if (data?['error_no']?.toString() == '0') {
+            final datas = data['data']?['datas'];
+            if (datas is! List) {
+              throw Exception("API返回格式异常");
+            }
             for (var item in datas) {
-              if (item['nickname'] == name) {
-                return SolvedNum(name: name, solvedNum: item['passNum']);
+              if (item?['nickname']?.toString().trim() == name.trim()) {
+                final passNum = item?['passNum'];
+                return SolvedNum(
+                    name: name, solvedNum: (passNum is num) ? passNum.toInt() : 0);
               }
             }
 
             // 检查是否还有更多数据
-            final total = data['data']['total'] as int;
+            final total = (data['data']?['total'] as num?)?.toInt() ?? 0;
             if (start + limit >= total) {
               break;
             }
@@ -293,10 +335,4 @@ class SolvedNumServices {
       throw Exception("查询码题集失败: $e");
     }
   }
-}
-
-void main() async {
-  final services = SolvedNumServices();
-  final nowcoder = await services.getCodeforcesSolvedNum(name: 'kano07');
-  print('Codeforces solved num: ${nowcoder.solvedNum}');
 }

--- a/lib/services/solved_num_services.dart
+++ b/lib/services/solved_num_services.dart
@@ -16,6 +16,7 @@ class SolvedNumServices {
     final response = await dio.get(url);
     if (response.statusCode == 200) {
       final data = response.data?['data'];
+      // ojhunt 对无效用户名可能返回空 data，直接索引会崩溃，先做防御
       if (data == null || data['solved'] == null) {
         throw Exception('查询失败或用户不存在');
       }
@@ -74,6 +75,7 @@ class SolvedNumServices {
         if (jsonData != null) {
           final data = json.decode(jsonData);
           final acAll = data?['counts']?['acAll'];
+          // counts/acAll 可能缺失（无 AC 记录或页面结构变化），缺失时防御性抛出
           if (acAll is num) {
             return SolvedNum(name: name, solvedNum: acAll.toInt());
           }
@@ -96,7 +98,9 @@ class SolvedNumServices {
     );
     final response = await dio.get(url, options: options);
     if (response.statusCode == 200) {
+      print(response.data); // 调试：查看洛谷搜索结果，便于排查
       final users = response.data?['users'];
+      // 搜索无结果时 users 为空数组，直接取 [0] 会越界崩溃，先做防御
       if (users is! List || users.isEmpty) {
         throw Exception('未找到该洛谷用户，请检查用户名');
       }
@@ -145,6 +149,7 @@ class SolvedNumServices {
     final response = await dio.get(url);
     if (response.statusCode == 200) {
       final data = response.data?['data'];
+      // ojhunt 对无效用户名可能返回空 data，直接索引会崩溃，先做防御
       if (data == null || data['solved'] == null) {
         throw Exception('查询失败或用户不存在');
       }
@@ -179,6 +184,7 @@ class SolvedNumServices {
     final response = await dio.get(url);
     if (response.statusCode == 200) {
       final data = response.data?['data'];
+      // ojhunt 对无效用户名可能返回空 data，直接索引会崩溃，先做防御
       if (data == null || data['solved'] == null) {
         throw Exception('查询失败或用户不存在');
       }
@@ -335,4 +341,11 @@ class SolvedNumServices {
       throw Exception("查询码题集失败: $e");
     }
   }
+}
+
+/// 调试入口：本地验证各平台解析逻辑（保留，便于后续开发时单独运行）
+void main() async {
+  final services = SolvedNumServices();
+  final nowcoder = await services.getCodeforcesSolvedNum(name: 'kano07');
+  print('Codeforces solved num: ${nowcoder.solvedNum}');
 }

--- a/lib/services/solved_num_services.dart
+++ b/lib/services/solved_num_services.dart
@@ -282,14 +282,14 @@ class SolvedNumServices {
       var limit = 25;
       var pageCount = 0;
       // 避免用户不存在时无限遍历整个排行榜
-      final maxPages = 2000;
+      const maxPages = 2000;
 
       while (true) {
         pageCount++;
         if (pageCount > maxPages) {
           throw Exception("未找到用户（已超过查询上限）");
         }
-        final url = 'https://www.matiji.net/exam-back/pc/ojRankByType.do';
+        const url = 'https://www.matiji.net/exam-back/pc/ojRankByType.do';
         final response = await dio.post(
           url,
           data: 'rankType=0&start=$start&limit=$limit',

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -93,6 +93,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
   void _showAddContestDialog() async {
     // 提前获取 prefs，避免在 onPressed 的 async 回调里 await 后使用 context
     prefs = await SharedPreferences.getInstance();
+    if (!context.mounted) return;
     int startTime = 0, endTime = 0, startYMDseconds = 0, endYMDseconds = 0;
     int startHMseconds = 0, endHMseconds = 0;
     TextEditingController startTimeController = TextEditingController();

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -91,6 +91,8 @@ class _FavoritesPageState extends State<FavoritesPage> {
 
   //添加比赛界面
   void _showAddContestDialog() async {
+    // 提前获取 prefs，避免在 onPressed 的 async 回调里 await 后使用 context
+    prefs = await SharedPreferences.getInstance();
     int startTime = 0, endTime = 0, startYMDseconds = 0, endYMDseconds = 0;
     int startHMseconds = 0, endHMseconds = 0;
     TextEditingController startTimeController = TextEditingController();
@@ -356,7 +358,6 @@ class _FavoritesPageState extends State<FavoritesPage> {
           ),
           TextButton(
             onPressed: () async {
-              prefs = await SharedPreferences.getInstance();
               if (startYMDseconds == 0 || startHMseconds == 0) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:oj_helper/models/contest.dart';
+import 'package:oj_helper/utils/favorite_utils.dart' show FavoriteUtils;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:day_night_time_picker/day_night_time_picker.dart';
@@ -24,23 +27,15 @@ class _FavoritesPageState extends State<FavoritesPage> {
   // 加载收藏夹
   void __loadFavoriteContest() async {
     prefs = await SharedPreferences.getInstance();
-    String? cur = prefs.getString('favourite_contests');
-    if (cur == null || cur == '') {
-      setState(() {});
-      return;
-    }
-    for (String s in cur.split(',')) {
+    final names = FavoriteUtils.getFavoriteNames(prefs);
+    for (String s in names) {
       if (s == '') continue;
-      String infor = prefs.getString(s) ?? '';
-      List<String> inforList = infor.split(',');
+      final infor = prefs.getString(s) ?? '';
       if (infor == '') continue;
-      favoriteContests.add(Contest.fromJson(
-        inforList[0],
-        int.parse(inforList[1]),
-        int.parse(inforList[2]),
-        inforList[3],
-        inforList[4],
-      ));
+      final contest = FavoriteUtils.parseStoredContest(infor);
+      if (contest != null) {
+        favoriteContests.add(contest);
+      }
     }
     favoriteContests
         .sort((a, b) => a.startTimeSeconds.compareTo(b.startTimeSeconds));
@@ -50,29 +45,11 @@ class _FavoritesPageState extends State<FavoritesPage> {
   // 删除比赛
   void _delFavoriteContest(Contest contest) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    String infor =
-        '${contest.name},${contest.startTimeSeconds},${contest.durationSeconds},${contest.platform},${contest.link}';
-    if (prefs.containsKey(contest.name)) {
+    final names = FavoriteUtils.getFavoriteNames(prefs);
+    if (names.contains(contest.name)) {
       await prefs.remove(contest.name);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        setState(() {});
-        return;
-      }
-      contestNames = cur.split(',');
-      contestNames.remove(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
-    } else {
-      await prefs.setString(contest.name, infor);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        setState(() {});
-        return;
-      }
-      contestNames.add(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
+      names.remove(contest.name);
+      await prefs.setString('favourite_contests', jsonEncode(names));
     }
     favoriteContests.remove(contest);
     setState(() {});
@@ -379,10 +356,18 @@ class _FavoritesPageState extends State<FavoritesPage> {
           ),
           TextButton(
             onPressed: () async {
-              if (startTime == 0 || endTime == 0) {
+              prefs = await SharedPreferences.getInstance();
+              if (startYMDseconds == 0 || startHMseconds == 0) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(
-                    content: Text('请选择开始时间和结束时间'),
+                    content: Text('请完整选择开始时间（日期和时分）'),
+                  ),
+                );
+                return;
+              } else if (endYMDseconds == 0 || endHMseconds == 0) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('请完整选择结束时间（日期和时分）'),
                   ),
                 );
                 return;
@@ -412,18 +397,14 @@ class _FavoritesPageState extends State<FavoritesPage> {
                   return;
                 }
               }
-              String infor =
-                  '$name,$startTime,${endTime - startTime},$platform,$link';
-              await prefs.setString(name, infor);
-              String? cur = prefs.getString('favourite_contests');
-              List<String> contestNames = [];
-              if (cur == null) {
-                setState(() {});
-                return;
-              }
-              contestNames = cur.split(',');
+              await prefs.setString(
+                  name,
+                  FavoriteUtils.encodeContest(
+                      name, startTime, endTime - startTime, platform, link));
+              final contestNames = FavoriteUtils.getFavoriteNames(prefs);
               contestNames.add(name);
-              prefs.setString('favourite_contests', contestNames.join(','));
+              await prefs.setString(
+                  'favourite_contests', jsonEncode(contestNames));
               favoriteContests.add(Contest.fromJson(
                   name, startTime, endTime - startTime, platform, link));
               favoriteContests.sort(

--- a/lib/ui/rating_page.dart
+++ b/lib/ui/rating_page.dart
@@ -39,7 +39,9 @@ class _RatingPageState extends State<RatingPage> {
   Future<void> _loadPersistedData() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     for (var platformName in _platformNames) {
-      String? storedUsername = prefs.getString(platformName);
+      // 优先读新 key（rating_ 前缀），兼容旧版本直接用平台名作 key 的数据
+      String? storedUsername = prefs.getString('rating_$platformName') ??
+          prefs.getString(platformName);
       if (storedUsername != null) {
         _usernameControllers[platformName]!.text = storedUsername;
         setState(() {});
@@ -50,7 +52,7 @@ class _RatingPageState extends State<RatingPage> {
   // 保存用户输入的用户名
   Future<void> _saveUsername(String platformName, String username) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setString(platformName, username);
+    await prefs.setString('rating_$platformName', username);
   }
 
   // // 加载折线图(TODO)

--- a/lib/ui/recent_contest_page.dart
+++ b/lib/ui/recent_contest_page.dart
@@ -1,9 +1,11 @@
-import 'package:dio/dio.dart';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:oj_helper/models/contest.dart' show Contest;
 import 'package:oj_helper/provider.dart';
 import 'package:oj_helper/ui/widgets/dialog_checkbox.dart' show DialogCheckbox;
 import 'package:oj_helper/utils/contest_utils.dart' show ContestUtils;
+import 'package:oj_helper/utils/favorite_utils.dart' show FavoriteUtils;
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -21,7 +23,6 @@ class _RecentContestPageState extends State<RecentContestPage>
   bool get wantKeepAlive => true;
   final platForms = ['Codeforces', 'AtCoder', '洛谷', '蓝桥云课', '力扣', '牛客'];
   // 按日期分类的比赛列表，长度为7
-  Dio dio = Dio();
   // 查询天数，默认7天
   int day = 7;
   // 加载状态
@@ -36,53 +37,57 @@ class _RecentContestPageState extends State<RecentContestPage>
         isLoading = true;
       });
     }
-    ContestProvider contestProvider =
-        Provider.of<ContestProvider>(context, listen: false);
-    List<List<Contest>> nowContests = await ContestUtils.getRecentContests(
-        day: day, contestProvider: contestProvider);
-    contestProvider.setContests(nowContests);
-    if (mounted) {
-      setState(() {
-        isLoading = false;
-      });
+    try {
+      ContestProvider contestProvider =
+          Provider.of<ContestProvider>(context, listen: false);
+      List<List<Contest>> nowContests = await ContestUtils.getRecentContests(
+          day: day, contestProvider: contestProvider);
+      contestProvider.setContests(nowContests);
+    } catch (e) {
+      // 任一平台请求失败时给出提示，避免页面永久停留在加载中
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('加载比赛失败，请检查网络后重试')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+      }
     }
   }
 
   //收藏比赛
   void _favoriteContest(Contest contest) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    String infor =
-        '${contest.name},${contest.startTimeSeconds},${contest.durationSeconds},${contest.platform},${contest.link}';
-    if (prefs.containsKey(contest.name)) {
+    List<String> contestNames = FavoriteUtils.getFavoriteNames(prefs);
+    if (contestNames.contains(contest.name)) {
       await prefs.remove(contest.name);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        prefs.setString('favourite_contests', '');
-        setState(() {});
-        return;
-      }
-      contestNames = cur.split(',');
       contestNames.remove(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
     } else {
-      await prefs.setString(contest.name, infor);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        prefs.setString('favourite_contests', '');
-        setState(() {});
-        return;
-      }
-      contestNames = cur.split(',');
+      await prefs.setString(
+          contest.name,
+          FavoriteUtils.encodeContest(contest.name, contest.startTimeSeconds,
+              contest.durationSeconds, contest.platform, contest.link));
       contestNames.add(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
     }
+    await prefs.setString('favourite_contests', jsonEncode(contestNames));
     setState(() {});
   }
 
   void _getSentences() async {
-    sentence = await sentenceServices.getSentences();
+    try {
+      final result = await sentenceServices.getSentences();
+      if (mounted) {
+        setState(() {
+          sentence = result;
+        });
+      }
+    } catch (e) {
+      // 网络失败时保持默认文案
+    }
   }
 
   void _wait() {
@@ -106,8 +111,18 @@ class _RecentContestPageState extends State<RecentContestPage>
   }
 
   @override
-  Widget build(BuildContext context) {
+  void initState() {
+    super.initState();
+    // 只在初始化时加载一次句子，避免 build 里反复发网络请求
     _getSentences();
+    // 初次进入页面自动加载近期比赛
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _loadContests();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     super.build(context);
     return Scaffold(
       appBar: AppBar(

--- a/lib/ui/solvednum_page.dart
+++ b/lib/ui/solvednum_page.dart
@@ -67,7 +67,9 @@ class _SolvedNumPageState extends State<SolvedNumPage> {
   Future<void> _loadPersistedData() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     for (var platformName in _platformNames) {
-      String? storedUsername = prefs.getString(platformName);
+      // 优先读新 key（solved_ 前缀），兼容旧版本直接用平台名作 key 的数据
+      String? storedUsername = prefs.getString('solved_$platformName') ??
+          prefs.getString(platformName);
       if (storedUsername != null) {
         _usernameControllers[platformName]!.text = storedUsername;
         setState(() {});
@@ -78,7 +80,7 @@ class _SolvedNumPageState extends State<SolvedNumPage> {
   // 保存用户输入的用户名
   Future<void> _saveUsername(String platformName, String username) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setString(platformName, username);
+    await prefs.setString('solved_$platformName', username);
   }
 
   //加载饼状图

--- a/lib/utils/favorite_utils.dart
+++ b/lib/utils/favorite_utils.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:oj_helper/models/contest.dart' show Contest;
+import 'package:shared_preferences/shared_preferences.dart';
+
+///收藏数据的存储工具。
+///
+///统一使用 JSON 数组格式存储比赛信息和收藏名称列表，避免比赛名含逗号
+///时旧"逗号分隔"格式导致的字段错位/崩溃；同时兼容读取旧格式数据。
+class FavoriteUtils {
+  ///读取收藏名称列表，兼容旧格式（逗号分隔）
+  static List<String> getFavoriteNames(SharedPreferences prefs) {
+    final cur = prefs.getString('favourite_contests');
+    if (cur == null || cur.isEmpty) return [];
+    try {
+      final decoded = jsonDecode(cur);
+      if (decoded is List) {
+        return decoded.map((e) => e.toString()).toList();
+      }
+    } catch (_) {
+      // 旧格式，走逗号分隔
+    }
+    return cur.split(',').where((e) => e.isNotEmpty).toList();
+  }
+
+  ///序列化比赛为 JSON 存储串（不再用逗号分隔，避免名字中的逗号破坏数据）
+  static String encodeContest(
+    String name,
+    int startTimeSeconds,
+    int durationSeconds,
+    String platform,
+    String? link,
+  ) {
+    return jsonEncode([
+      name,
+      startTimeSeconds,
+      durationSeconds,
+      platform,
+      link,
+    ]);
+  }
+
+  ///从存储数据解析 Contest（兼容 JSON / 旧逗号两种格式），解析失败返回 null
+  static Contest? parseStoredContest(String infor) {
+    try {
+      final decoded = jsonDecode(infor);
+      if (decoded is List && decoded.length >= 4) {
+        final link = decoded.length > 4 &&
+                decoded[4] != null &&
+                decoded[4].toString().isNotEmpty
+            ? decoded[4].toString()
+            : null;
+        return Contest.fromJson(
+          decoded[0].toString(),
+          (decoded[1] as num).toInt(),
+          (decoded[2] as num).toInt(),
+          decoded[3].toString(),
+          link,
+        );
+      }
+    } catch (_) {
+      // 不是 JSON，走旧格式
+    }
+    // 兼容旧格式：逗号分隔
+    final inforList = infor.split(',');
+    if (inforList.length < 4) return null;
+    final start = int.tryParse(inforList[1]);
+    final duration = int.tryParse(inforList[2]);
+    if (start == null || duration == null) return null;
+    final link = inforList.length > 4 && inforList[4].isNotEmpty
+        ? inforList[4]
+        : null;
+    return Contest.fromJson(
+      inforList[0],
+      start,
+      duration,
+      inforList[3],
+      link,
+    );
+  }
+}

--- a/lib/utils/rating_utils.dart
+++ b/lib/utils/rating_utils.dart
@@ -10,7 +10,11 @@ class RatingUtils {
       case 'AtCoder':
         return await rs.getAtCoderRating(name: name);
       case '力扣':
-        return (await rs.getLeetCodeRating(name: name)).last;
+        final ratingList = await rs.getLeetCodeRating(name: name);
+        if (ratingList.isEmpty) {
+          throw Exception('该用户暂未参加力扣竞赛');
+        }
+        return ratingList.last;
       case '牛客':
         return await rs.getNowcoderRating(name: name);
       case '洛谷':


### PR DESCRIPTION
## 背景

用户不存在、新账号暂无数据、接口返回异常等场景下，多个平台的查询会直接崩溃或页面卡死；收藏夹在比赛名含逗号时会解析错乱、字段错位导致崩溃。

## 修改范围（8 个文件，+321 / -150）

| 文件 | 改动 |
| --- | --- |
| `lib/services/rating_services.dart` | CF/AtCoder/洛谷/牛客查询崩溃防护、Dio 超时 |
| `lib/services/solved_num_services.dart` | 力扣/洛谷/VJudge/ojhunt/码题集解析防护、Dio 超时 |
| `lib/utils/rating_utils.dart` | 力扣历史为空时抛可读异常（不再 `.last` 崩溃） |
| `lib/ui/favorites_page.dart` | 收藏改用 JSON 存储；添加比赛必须完整选择日期+时分 |
| `lib/ui/recent_contest_page.dart` | 加载比赛失败不再卡死；收藏逻辑同步 JSON 化 |
| `lib/ui/rating_page.dart` | 本地存储 key 增加 `rating_` 前缀 |
| `lib/ui/solvednum_page.dart` | 本地存储 key 增加 `solved_` 前缀 |
| `lib/utils/favorite_utils.dart`（新增） | 收藏 JSON 序列化/反序列化，兼容旧格式 |

## 改动明细

### 1. 查询崩溃防护（rating_services.dart / solved_num_services.dart）

- **Codeforces rating**：原代码直接取 `result[0]['rating']`，用户不存在时 API 返回 `status=FAILED` 且 `result` 为错误字符串（按字符索引崩溃）；新账号 `rating` 为 `null` 时构造 `Rating(curRating: null)` 触发类型错误。现改为：校验 `status == 'OK'` 且 `result` 非空，`rating`/`maxRating` 为 `null` 时按 `0` 处理，否则抛"请求失败或用户不存在"。
- **AtCoder rating**：原代码 `getElementsByClassName('dl-table mt-2')[0]` 越界即崩；未参赛用户 rating 显示 `-`，`int.parse('-')` 抛 `FormatException`。现改为：先检查表格存在与行数，rating 文本为 `-` 或空时抛"该用户暂无 rating"。
- **洛谷**：搜索无结果时 `users` 为空数组，`users[0]` 越界。现改为：`users` 为空抛"未找到该洛谷用户"；elo 记录为空抛"暂无 rating 记录"。
- **力扣（题数）**：新用户 `numAcceptedQuestions` 可能为 `null`/空数组，原代码 `infor[0]` 越界，且按 `[0][1][2]` 硬编码难度顺序。现改为遍历数组累加 `count`，空数据返回 `0`。
- **牛客**：`rateHistory` 为空时 `.last` 越界、`rating` 为 `null` 时 `.toInt()` 崩溃。现改为：空列表抛"暂无 rating 记录"，rating 用 `num` 类型安全转换。
- **VJudge / ojhunt（CF/HDU/牛客）**：返回 `data` 或 `solved` 缺失时原代码直接索引崩溃。现统一改为缺失即抛"查询失败或用户不存在"。
- **码题集**：`error_no` 可能是数字或字符串（原 `== '0'` 字符串比较在数字时永不匹配）；`datas`/`total` 可能为 `null` 导致强转崩溃；用户不存在时会无限翻页。现改为：`toString()` 统一比较、`datas` 校验为 `List`、`total` 用 `num` 安全转换、昵称 `trim` 后匹配、增加 2000 页上限。

### 2. 收藏夹 JSON 化（favorite_utils.dart 新增 + favorites_page.dart / recent_contest_page.dart）

- **问题**：原方案用比赛名做 key、用逗号分隔存字段（`名字,时间戳,时长,平台,链接`），比赛名含逗号时 `split(',')` 字段错位，`int.parse` 抛异常导致整个收藏页崩溃。
- **改法**：新增 `FavoriteUtils`，统一 JSON 数组存储（`encodeContest` / `parseStoredContest` / `getFavoriteNames`），并**兼容读取旧逗号格式**——旧数据能正常迁移显示，损坏数据安全跳过（返回 null）而不是崩溃。
- **添加比赛校验**：原只校验 `startTime == 0`，只选了"时分"没选"日期"时会存出 1970 年的错误时间。现改为分别校验日期分量与时分分量，缺一即提示"请完整选择时间"。

### 3. 近期比赛加载不再卡死（recent_contest_page.dart）

原 `_loadContests()` 是 `async void` 且无 try-catch，任一平台请求失败异常直接逃逸，`isLoading` 永远为 `true`，页面永久转圈。现改为 try/catch/finally：失败弹 SnackBar 提示，`isLoading` 在 `finally` 中必定复位。

### 4. 题数/分数两页本地存储 key 隔离（solvednum_page.dart / rating_page.dart）

两个页面原共用 `平台名` 作 SharedPreferences key，互相覆盖用户名。现分别使用 `solved_` / `rating_` 前缀，读取时回退旧 key 保证老用户数据不丢。

### 5. 其他

- 所有 service 的 `Dio` 增加超时（connect 10s / receive 20s），避免接口挂起时永久 loading。
- **原调试代码全部保留**：`rating_services.dart`、`solved_num_services.dart` 底部的 `main()` 调试入口、洛谷搜索的 `print(response.data)` 均未删除，并补了注释说明用途，后续开发者可单独运行验证解析。
- 关键防御逻辑处均补充了注释（如"搜索无结果时 users 为空数组，直接取 [0] 会越界崩溃"）。