### PR TITLE
fix: 平台查询崩溃防护、近期比赛时间逻辑修正、版本比较/Tab 状态/图表修复，并补充单元测试

### DIFF
--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -52,7 +52,9 @@ class ContestProvider extends ChangeNotifier {
   //显示有无比赛日
   bool showEmptyDay = true;
   void toggleShowEmptyDay(bool value) {
-    showEmptyDay = !showEmptyDay;
+    // 参数 value 是开关期望的目标状态，直接赋值而非取反，
+    // 避免状态与 UI 脱钩（旧实现忽略了参数）
+    showEmptyDay = value;
     notifyListeners(); // 通知监听器更新 UI
   }
 }

--- a/lib/services/rating_services.dart
+++ b/lib/services/rating_services.dart
@@ -3,19 +3,27 @@ import 'package:oj_helper/models/rating.dart' show Rating;
 import 'package:html/parser.dart' show parse;
 
 class RatingService {
-  final Dio dio = Dio();
+  final Dio dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
 
   ///获取codeforces的curRating,maxRating
   Future<Rating> getCodeforcesRating({name = ''}) async {
     final url =
         "https://codeforces.com/api/user.info?handles=$name&checkHistoricHandles=false";
     Response response = await dio.get(url);
-    if (response.statusCode == 200) {
-      final rating = response.data['result'][0]['rating'];
-      final maxRating = response.data['result'][0]['maxRating'];
+    // 用户不存在时 API 返回 status=FAILED 且 result 为错误信息字符串；
+    // 新账号可能没有 rating/maxRating（为 null），统一按 0 处理
+    if (response.statusCode == 200 &&
+        response.data['status'] == 'OK' &&
+        (response.data['result'] as List).isNotEmpty) {
+      final result = response.data['result'][0];
+      final rating = (result['rating'] ?? 0) as int;
+      final maxRating = (result['maxRating'] ?? 0) as int;
       return Rating(name: name, curRating: rating, maxRating: maxRating);
     } else {
-      throw Exception("请求失败，状态码：${response.statusCode}");
+      throw Exception("请求失败或用户不存在");
     }
   }
 
@@ -25,13 +33,25 @@ class RatingService {
     Response response = await dio.get(url);
     if (response.statusCode == 200) {
       final document = parse(response.data);
-      final rating = document
-          .getElementsByClassName('dl-table mt-2')[0]
-          .getElementsByTagName('tr');
+      final tables = document.getElementsByClassName('dl-table mt-2');
+      if (tables.isEmpty) {
+        throw Exception('无法解析 AtCoder 页面（页面可能改版或用户不存在）');
+      }
+      final rating = tables[0].getElementsByTagName('tr');
+      if (rating.length < 3) {
+        throw Exception('无法解析 AtCoder rating 数据');
+      }
+      // 未参赛用户页面显示 '-'，int.parse 会抛 FormatException，先做防御
+      int parseRating(int index) {
+        final spans = rating[index].getElementsByTagName('span');
+        final text = spans.isEmpty ? '-' : spans[0].text.trim();
+        if (text.isEmpty || text == '-') {
+          throw Exception('该用户暂无 rating');
+        }
+        return int.parse(text);
+      }
       return Rating(
-          name: name,
-          curRating: int.parse(rating[1].getElementsByTagName('span')[0].text),
-          maxRating: int.parse(rating[2].getElementsByTagName('span')[0].text));
+          name: name, curRating: parseRating(1), maxRating: parseRating(2));
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -97,19 +117,27 @@ class RatingService {
     );
     int userId;
     Response response = await dio.get(baseUrl, options: options);
-    if (response.statusCode == 200) {
-      userId = response.data['users'][0]['uid'];
-    } else {
+    if (response.statusCode != 200) {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
+    final users = response.data?['users'];
+    if (users is! List || users.isEmpty) {
+      throw Exception('未找到该洛谷用户，请检查用户名');
+    }
+    userId = users[0]['uid'];
     final url =
         'https://www.luogu.com.cn/api/rating/elo?user=$userId&page=1&limit=100';
     response = await dio.get(url, options: options);
     if (response.statusCode == 200) {
-      final curRating = response.data['records']['result'][0]['rating'];
+      final records = response.data?['records']?['result'];
+      if (records is! List || records.isEmpty) {
+        throw Exception('该用户暂无 rating 记录');
+      }
+      final curRating = (records[0]['rating'] ?? 0) as int;
       int maxRating = 0;
-      for (var i in response.data['records']['result']) {
-        maxRating = i['rating'] > maxRating ? i['rating'] : maxRating;
+      for (final i in records) {
+        final r = (i['rating'] ?? 0) as int;
+        maxRating = r > maxRating ? r : maxRating;
       }
       return Rating(name: name, curRating: curRating, maxRating: maxRating);
     } else {
@@ -122,25 +150,21 @@ class RatingService {
     final url = 'https://ac.nowcoder.com/acm/contest/rating-history?uid=$name';
     Response response = await dio.get(url);
     if (response.statusCode == 200) {
-      final rateHistory = response.data['data'];
-      final curRating = rateHistory.last['rating'].toInt();
+      final rateHistory = response.data?['data'];
+      if (rateHistory is! List || rateHistory.isEmpty) {
+        throw Exception('该用户暂无 rating 记录');
+      }
+      int toRating(dynamic v) => (v is num) ? v.toInt() : 0;
+      final curRating = toRating(rateHistory.last['rating']);
       //获取rateHisory的最大rating
       int maxRating = 0;
       for (var i in rateHistory) {
-        maxRating =
-            i['rating'].toInt() > maxRating ? i['rating'].toInt() : maxRating;
+        final r = toRating(i['rating']);
+        maxRating = r > maxRating ? r : maxRating;
       }
       return Rating(name: name, curRating: curRating, maxRating: maxRating);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
-  }
-}
-
-void main() async {
-  RatingService rs = RatingService();
-  var tmp = await rs.getLeetCodeRating(name: 'lu-ming-b');
-  for (var i in tmp) {
-    print("${i.name} ${i.curRating} ${i.maxRating} ${i.time} ${i.ranking}");
   }
 }

--- a/lib/services/rating_services.dart
+++ b/lib/services/rating_services.dart
@@ -121,6 +121,7 @@ class RatingService {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
     final users = response.data?['users'];
+    // 搜索无结果时 users 为空数组，直接取 [0] 会越界崩溃，先做防御
     if (users is! List || users.isEmpty) {
       throw Exception('未找到该洛谷用户，请检查用户名');
     }
@@ -151,6 +152,7 @@ class RatingService {
     Response response = await dio.get(url);
     if (response.statusCode == 200) {
       final rateHistory = response.data?['data'];
+      // 未参赛用户没有 rating 历史（空列表），取 .last 会越界；rating 也可能为 null
       if (rateHistory is! List || rateHistory.isEmpty) {
         throw Exception('该用户暂无 rating 记录');
       }
@@ -166,5 +168,14 @@ class RatingService {
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
+  }
+}
+
+/// 调试入口：本地验证各平台解析逻辑（保留，便于后续开发时单独运行）
+void main() async {
+  RatingService rs = RatingService();
+  var tmp = await rs.getLeetCodeRating(name: 'lu-ming-b');
+  for (var i in tmp) {
+    print("${i.name} ${i.curRating} ${i.maxRating} ${i.time} ${i.ranking}");
   }
 }

--- a/lib/services/recent_contest_services.dart
+++ b/lib/services/recent_contest_services.dart
@@ -279,6 +279,7 @@ class RecentContestServices {
           continue;
         }
         final link = "https://www.lanqiao.cn$htmlUrl";
+        print(link); // 调试：打印蓝桥比赛链接，便于排查
         //time格式如2024-06-29T19:00:00+08:00
         DateFormat starttimeFormat = DateFormat('yyyy-MM-ddTHH:mm:ssZ');
         final startTime = starttimeFormat
@@ -301,4 +302,10 @@ class RecentContestServices {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
   }
+}
+
+/// 调试入口：本地验证各平台比赛列表解析（保留，便于后续开发时单独运行）
+void main() async {
+  RecentContestServices r = RecentContestServices();
+  r.getLuoguContests();
 }

--- a/lib/services/recent_contest_services.dart
+++ b/lib/services/recent_contest_services.dart
@@ -15,28 +15,50 @@ class RecentContestServices {
   final _lanqiaoUrl =
       "https://www.lanqiao.cn/api/v2/contests/?sort=opentime&paginate=0&status=not_finished&game_type_code=2";
   final _nowcoderUrl = "https://ac.nowcoder.com/acm/contest/vip-index";
-  final Dio dio = Dio();
-  final int _nowSconds = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  final Dio dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
   int _queryEndSeconds = 7 * 24 * 60 * 60; //最晚时间
-  int midnightSeconds = DateTime.now().millisecondsSinceEpoch ~/ 1000 -
-      DateTime.now().hour * 3600;
+
+  // 今天零点（本地）对应的 Unix 秒，每次访问重新计算，避免跨天 stale
+  int get midnightSeconds {
+    final now = DateTime.now();
+    final midnight = DateTime(now.year, now.month, now.day);
+    return midnight.millisecondsSinceEpoch ~/ 1000;
+  }
 
   ///修改查询最晚时间
   void setDay(int day) {
     _queryEndSeconds = day * 24 * 60 * 60;
   }
 
-  ///判断比赛时间是否符合时间范围
+  ///判断比赛时间是否符合时间范围（公开静态，便于单元测试）
   ///@return: 比赛过早返回2，比赛过晚返回1，其余返回0
-  int _isIntime({int startTime = 0, int duration = 0}) {
+  static int isInTime({
+    required int startTime,
+    required int duration,
+    required int queryEndSeconds,
+    required int midnightSeconds,
+  }) {
     int endTime = startTime + duration;
-    if (startTime > _queryEndSeconds + midnightSeconds ||
-        duration >= 24 * 60 * 60) {
+    if (startTime > queryEndSeconds + midnightSeconds) {
       return 1;
     } else if (endTime < midnightSeconds) {
       return 2;
     }
     return 0;
+  }
+
+  ///判断比赛时间是否符合时间范围
+  ///@return: 比赛过早返回2，比赛过晚返回1，其余返回0
+  int _isIntime({int startTime = 0, int duration = 0}) {
+    return isInTime(
+      startTime: startTime,
+      duration: duration,
+      queryEndSeconds: _queryEndSeconds,
+      midnightSeconds: midnightSeconds,
+    );
   }
 
   ///获取力扣比赛
@@ -113,20 +135,27 @@ class RecentContestServices {
       final document = parse(response.data);
       final contestList = document.getElementsByClassName("platform-item-main");
       for (var i = 0; i < contestList.length; i++) {
-        final title = contestList[i].getElementsByTagName("a")[0].text;
-        final link =
-            "https://ac.nowcoder.com${contestList[i].getElementsByTagName("a")[0].attributes['href']!}";
+        final links = contestList[i].getElementsByTagName("a");
+        if (links.isEmpty) continue;
+        final href = links[0].attributes['href'];
+        if (href == null) continue;
+        final title = links[0].text;
+        final link = "https://ac.nowcoder.com$href";
         //time格式如下
         // 比赛时间：    2024-06-23 19:00
         //  至     2024-06-23 21:00
         //  (时长:2小时)
-        final time =
-            contestList[i].getElementsByClassName("match-time-icon")[0].text;
+        final timeIcons =
+            contestList[i].getElementsByClassName("match-time-icon");
+        if (timeIcons.isEmpty) continue;
+        final time = timeIcons[0].text;
         // 查找所有匹配的时间，格式如2024-06-23 21:00
         final RegExp timeRegExp = RegExp(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}');
-        final matches = timeRegExp.allMatches(time);
-        final startTimeStr = matches.elementAt(0).group(0)!;
-        final endTimeStr = matches.elementAt(1).group(0)!;
+        final matches = timeRegExp.allMatches(time).toList();
+        // 时间信息不完整（如已结束的比赛）时跳过，而不是崩溃
+        if (matches.length < 2) continue;
+        final startTimeStr = matches[0].group(0)!;
+        final endTimeStr = matches[1].group(0)!;
         //转换成unix时间戳
         final startTime =
             DateTime.parse(startTimeStr).millisecondsSinceEpoch ~/ 1000;
@@ -169,11 +198,13 @@ class RecentContestServices {
             .text
             .split(':');
         //转换为 Unix 时间戳
-        //原格式time：2024-06-29 21:00:00+0900
+        //原格式time：2024-06-29 21:00:00+0900（已含时区偏移）
         //原格式duration：02:00
+        //注意：DateFormat('...Z') 解析带时区的时间后，millisecondsSinceEpoch
+        //已经是绝对时刻（JST 21:00 = 北京 20:00），不要再手动减小时差
         DateFormat starttimeFormat = DateFormat('yyyy-MM-dd HH:mm:ssZ');
         final startTime =
-            starttimeFormat.parse(time).millisecondsSinceEpoch ~/ 1000 - 3600;
+            starttimeFormat.parse(time).millisecondsSinceEpoch ~/ 1000;
         int durationTime =
             int.parse(duration[0]) * 3600 + int.parse(duration[1]) * 60;
         //判断时间范围
@@ -229,18 +260,33 @@ class RecentContestServices {
   Future<List<Contest>> getLanqiaoContests() async {
     Response response = await dio.get(_lanqiaoUrl);
     if (response.statusCode == 200) {
+      // 兼容接口返回 List 或 {data: [...]} 两种结构
+      final raw = response.data;
+      final List<dynamic> list = raw is List
+          ? raw
+          : ((raw is Map && raw['data'] is List)
+              ? raw['data'] as List
+              : []);
       List<Contest> contests = [];
-      for (var i = 0; i < response.data.length; i++) {
-        final name = response.data[i]['name'];
-        final link = "https://www.lanqiao.cn${response.data[i]['html_url']}";
-        print(link);
+      for (var i = 0; i < list.length; i++) {
+        final item = list[i];
+        if (item == null) continue;
+        final name = item['name'];
+        final htmlUrl = item['html_url'];
+        final time = item['open_at'];
+        final endAt = item['end_at'];
+        if (name == null || htmlUrl == null || time == null || endAt == null) {
+          continue;
+        }
+        final link = "https://www.lanqiao.cn$htmlUrl";
         //time格式如2024-06-29T19:00:00+08:00
-        final time = response.data[i]['open_at'];
         DateFormat starttimeFormat = DateFormat('yyyy-MM-ddTHH:mm:ssZ');
-        final startTime =
-            starttimeFormat.parse(time).millisecondsSinceEpoch ~/ 1000;
+        final startTime = starttimeFormat
+            .parse(time.toString())
+            .millisecondsSinceEpoch ~/
+            1000;
         final endTime = starttimeFormat
-            .parse(response.data[i]['end_at'])
+            .parse(endAt.toString())
             .millisecondsSinceEpoch ~/
             1000;
         final duration = endTime - startTime;
@@ -255,9 +301,4 @@ class RecentContestServices {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
   }
-}
-
-void main() async {
-  RecentContestServices r = RecentContestServices();
-  r.getLuoguContests();
 }

--- a/lib/services/report_services.dart
+++ b/lib/services/report_services.dart
@@ -1,10 +1,14 @@
 import 'package:dio/dio.dart';
 
 class ReportServices {
-  final dio = Dio();
+  final dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
   Future<List<Map<String, dynamic>>> fetchCodeforcesData(String handle) async {
+    // CF API 对 user.status 的 count 有上限（约 1e4 条），过大会被拒绝
     final codeforcesUrl =
-        'https://codeforces.com/api/user.status?handle=$handle&from=1&count=1000000000';
+        'https://codeforces.com/api/user.status?handle=$handle&from=1&count=10000';
     final response = await dio.get(codeforcesUrl);
     if (response.statusCode != 200 || response.data['status'] != 'OK') {
       throw Exception('Failed to fetch data: ${response.data['comment']}');

--- a/lib/services/sentence_services.dart
+++ b/lib/services/sentence_services.dart
@@ -1,7 +1,10 @@
 import 'package:dio/dio.dart';
 
 class SentenceServices {
-  final Dio dio = Dio();
+  final Dio dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
   Future<Map<String, dynamic>> getSentences() async {
     final url = 'https://v1.jinrishici.com/all.json';
     final response = await dio.get(url);

--- a/lib/services/solved_num_services.dart
+++ b/lib/services/solved_num_services.dart
@@ -4,7 +4,10 @@ import 'package:html/parser.dart' show parse;
 import 'package:oj_helper/models/solved_num.dart' show SolvedNum;
 
 class SolvedNumServices {
-  final dio = Dio();
+  final dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 20),
+  ));
 
   /// 获取codeforces的解题数
   ///   //数据来源：https://github.com/Liu233w/acm-statistics
@@ -12,7 +15,11 @@ class SolvedNumServices {
     final url = 'https://ojhunt.com/api/crawlers/codeforces/$name';
     final response = await dio.get(url);
     if (response.statusCode == 200) {
-      return SolvedNum(name: name, solvedNum: response.data['data']['solved']);
+      final data = response.data?['data'];
+      if (data == null || data['solved'] == null) {
+        throw Exception('查询失败或用户不存在');
+      }
+      return SolvedNum(name: name, solvedNum: data['solved'] as int);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -37,12 +44,16 @@ class SolvedNumServices {
     };
     Response response = await dio.post(url, data: data);
     if (response.statusCode == 200) {
-      final infor = response.data['data']['userProfileUserQuestionProgressV2']
-          ['numAcceptedQuestions'];
-      final easySolvedNum = infor[0]['count'];
-      final mediumSolvedNum = infor[1]['count'];
-      final hardSolvedNum = infor[2]['count'];
-      final totalSolvedNum = easySolvedNum + mediumSolvedNum + hardSolvedNum;
+      final progress = response.data?['data']
+          ?['userProfileUserQuestionProgressV2'];
+      final infor = progress?['numAcceptedQuestions'];
+      // 新用户可能没有做题记录（数组为空或字段缺失），按 0 处理
+      int totalSolvedNum = 0;
+      if (infor is List) {
+        for (final item in infor) {
+          totalSolvedNum += (item?['count'] as int? ?? 0);
+        }
+      }
       return SolvedNum(name: name, solvedNum: totalSolvedNum);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
@@ -62,8 +73,11 @@ class SolvedNumServices {
         final jsonData = match.group(1);
         if (jsonData != null) {
           final data = json.decode(jsonData);
-          final solvedNum = data['counts']['acAll'] as int;
-          return SolvedNum(name: name, solvedNum: solvedNum);
+          final acAll = data?['counts']?['acAll'];
+          if (acAll is num) {
+            return SolvedNum(name: name, solvedNum: acAll.toInt());
+          }
+          throw Exception('无法解析Vjudge数据');
         }
       }
       throw Exception('无法解析Vjudge数据');
@@ -82,16 +96,23 @@ class SolvedNumServices {
     );
     final response = await dio.get(url, options: options);
     if (response.statusCode == 200) {
-      print(response.data);
-      int userId = response.data['users'][0]['uid'];
+      final users = response.data?['users'];
+      if (users is! List || users.isEmpty) {
+        throw Exception('未找到该洛谷用户，请检查用户名');
+      }
+      int userId = users[0]['uid'];
       final url = 'https://www.luogu.com.cn/user/$userId';
       final res = await dio.get(url, options: options);
       if (res.statusCode == 200) {
-        final text = res.data
-            .toString()
-            .split('passedProblemCount')[1]
-            .split('submittedProblemCount')[0];
-        String decodedString = Uri.decodeComponent(text);
+        final parts = res.data.toString().split('passedProblemCount');
+        if (parts.length < 2) {
+          throw Exception('无法解析洛谷数据');
+        }
+        final subParts = parts[1].split('submittedProblemCount');
+        String decodedString = Uri.decodeComponent(subParts[0]);
+        if (decodedString.length < 4) {
+          throw Exception('无法解析洛谷数据');
+        }
         decodedString = decodedString.substring(2, decodedString.length - 2);
         final solvedNum = int.parse(decodedString);
         return SolvedNum(name: name, solvedNum: solvedNum);
@@ -123,7 +144,11 @@ class SolvedNumServices {
     final url = 'https://ojhunt.com/api/crawlers/hdu/$name';
     final response = await dio.get(url);
     if (response.statusCode == 200) {
-      return SolvedNum(name: name, solvedNum: response.data['data']['solved']);
+      final data = response.data?['data'];
+      if (data == null || data['solved'] == null) {
+        throw Exception('查询失败或用户不存在');
+      }
+      return SolvedNum(name: name, solvedNum: data['solved'] as int);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -153,7 +178,11 @@ class SolvedNumServices {
     final url = 'https://ojhunt.com/api/crawlers/nowcoder/$name';
     final response = await dio.get(url);
     if (response.statusCode == 200) {
-      return SolvedNum(name: name, solvedNum: response.data['data']['solved']);
+      final data = response.data?['data'];
+      if (data == null || data['solved'] == null) {
+        throw Exception('查询失败或用户不存在');
+      }
+      return SolvedNum(name: name, solvedNum: data['solved'] as int);
     } else {
       throw Exception("请求失败，状态码：${response.statusCode}");
     }
@@ -251,8 +280,15 @@ class SolvedNumServices {
     try {
       var start = 0;
       var limit = 25;
+      var pageCount = 0;
+      // 避免用户不存在时无限遍历整个排行榜
+      final maxPages = 2000;
 
       while (true) {
+        pageCount++;
+        if (pageCount > maxPages) {
+          throw Exception("未找到用户（已超过查询上限）");
+        }
         final url = 'https://www.matiji.net/exam-back/pc/ojRankByType.do';
         final response = await dio.post(
           url,
@@ -266,16 +302,22 @@ class SolvedNumServices {
 
         if (response.statusCode == 200) {
           final data = response.data;
-          if (data['error_no'] == '0') {
-            final datas = data['data']['datas'] as List;
+          // error_no 可能以字符串或数字形式返回，统一转字符串比较
+          if (data?['error_no']?.toString() == '0') {
+            final datas = data['data']?['datas'];
+            if (datas is! List) {
+              throw Exception("API返回格式异常");
+            }
             for (var item in datas) {
-              if (item['nickname'] == name) {
-                return SolvedNum(name: name, solvedNum: item['passNum']);
+              if (item?['nickname']?.toString().trim() == name.trim()) {
+                final passNum = item?['passNum'];
+                return SolvedNum(
+                    name: name, solvedNum: (passNum is num) ? passNum.toInt() : 0);
               }
             }
 
             // 检查是否还有更多数据
-            final total = data['data']['total'] as int;
+            final total = (data['data']?['total'] as num?)?.toInt() ?? 0;
             if (start + limit >= total) {
               break;
             }
@@ -293,10 +335,4 @@ class SolvedNumServices {
       throw Exception("查询码题集失败: $e");
     }
   }
-}
-
-void main() async {
-  final services = SolvedNumServices();
-  final nowcoder = await services.getCodeforcesSolvedNum(name: 'kano07');
-  print('Codeforces solved num: ${nowcoder.solvedNum}');
 }

--- a/lib/services/solved_num_services.dart
+++ b/lib/services/solved_num_services.dart
@@ -16,6 +16,7 @@ class SolvedNumServices {
     final response = await dio.get(url);
     if (response.statusCode == 200) {
       final data = response.data?['data'];
+      // ojhunt 对无效用户名可能返回空 data，直接索引会崩溃，先做防御
       if (data == null || data['solved'] == null) {
         throw Exception('查询失败或用户不存在');
       }
@@ -74,6 +75,7 @@ class SolvedNumServices {
         if (jsonData != null) {
           final data = json.decode(jsonData);
           final acAll = data?['counts']?['acAll'];
+          // counts/acAll 可能缺失（无 AC 记录或页面结构变化），缺失时防御性抛出
           if (acAll is num) {
             return SolvedNum(name: name, solvedNum: acAll.toInt());
           }
@@ -96,7 +98,9 @@ class SolvedNumServices {
     );
     final response = await dio.get(url, options: options);
     if (response.statusCode == 200) {
+      print(response.data); // 调试：查看洛谷搜索结果，便于排查
       final users = response.data?['users'];
+      // 搜索无结果时 users 为空数组，直接取 [0] 会越界崩溃，先做防御
       if (users is! List || users.isEmpty) {
         throw Exception('未找到该洛谷用户，请检查用户名');
       }
@@ -145,6 +149,7 @@ class SolvedNumServices {
     final response = await dio.get(url);
     if (response.statusCode == 200) {
       final data = response.data?['data'];
+      // ojhunt 对无效用户名可能返回空 data，直接索引会崩溃，先做防御
       if (data == null || data['solved'] == null) {
         throw Exception('查询失败或用户不存在');
       }
@@ -179,6 +184,7 @@ class SolvedNumServices {
     final response = await dio.get(url);
     if (response.statusCode == 200) {
       final data = response.data?['data'];
+      // ojhunt 对无效用户名可能返回空 data，直接索引会崩溃，先做防御
       if (data == null || data['solved'] == null) {
         throw Exception('查询失败或用户不存在');
       }
@@ -335,4 +341,11 @@ class SolvedNumServices {
       throw Exception("查询码题集失败: $e");
     }
   }
+}
+
+/// 调试入口：本地验证各平台解析逻辑（保留，便于后续开发时单独运行）
+void main() async {
+  final services = SolvedNumServices();
+  final nowcoder = await services.getCodeforcesSolvedNum(name: 'kano07');
+  print('Codeforces solved num: ${nowcoder.solvedNum}');
 }

--- a/lib/services/solved_num_services.dart
+++ b/lib/services/solved_num_services.dart
@@ -282,14 +282,14 @@ class SolvedNumServices {
       var limit = 25;
       var pageCount = 0;
       // 避免用户不存在时无限遍历整个排行榜
-      final maxPages = 2000;
+      const maxPages = 2000;
 
       while (true) {
         pageCount++;
         if (pageCount > maxPages) {
           throw Exception("未找到用户（已超过查询上限）");
         }
-        final url = 'https://www.matiji.net/exam-back/pc/ojRankByType.do';
+        const url = 'https://www.matiji.net/exam-back/pc/ojRankByType.do';
         final response = await dio.post(
           url,
           data: 'rankType=0&start=$start&limit=$limit',

--- a/lib/ui/cf_report_page.dart
+++ b/lib/ui/cf_report_page.dart
@@ -44,6 +44,7 @@ class _CfReportPageState extends State<CfReportPage> {
       }
       return;
     }
+    // 统计每题涉及的所有 tag（同一题可含多个 tag），按数量生成饼图
     Map<String, int> tag = {};
     for (var i in data) {
       for (var j in (i['tags'] as List? ?? [])) {
@@ -51,6 +52,7 @@ class _CfReportPageState extends State<CfReportPage> {
         tag[key] = (tag[key] ?? 0) + 1;
       }
     }
+    // 按数量降序排列，保证饼图从大到小展示，颜色循环分配
     final sorted = tag.entries.toList()
       ..sort((a, b) => b.value.compareTo(a.value));
     setState(() {

--- a/lib/ui/cf_report_page.dart
+++ b/lib/ui/cf_report_page.dart
@@ -15,21 +15,56 @@ class _CfReportPageState extends State<CfReportPage> {
   ReportServices report = ReportServices();
   final TextEditingController _controller = TextEditingController();
 
+  static const List<Color> _pieColors = [
+    Colors.blue,
+    Colors.green,
+    Colors.orange,
+    Colors.redAccent,
+    Colors.purple,
+    Colors.teal,
+    Colors.pink,
+    Colors.indigo,
+    Colors.brown,
+    Colors.cyan,
+    Colors.lime,
+    Colors.amber,
+  ];
+
   void _fetchData() async {
-    String username = _controller.text;
-    List<Map<String, dynamic>> data =
-        await report.fetchCodeforcesData(username);
-    Map<String, int> tag = {};
-    Map<int, int> rating = {};
-    for (var i in data) {
-      for (var j in i['tags']) {
-        tag[j] = tag[j] == null ? 1 : tag[j]! + 1;
+    String username = _controller.text.trim();
+    if (username.isEmpty) return;
+    List<Map<String, dynamic>> data;
+    try {
+      data = await report.fetchCodeforcesData(username);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('查询失败，请检查用户名或网络')),
+        );
       }
-      rating[i['rating']] =
-          rating[i['rating']] == null ? 1 : rating[i['rating']]! + 1;
+      return;
     }
+    Map<String, int> tag = {};
+    for (var i in data) {
+      for (var j in (i['tags'] as List? ?? [])) {
+        final key = j.toString();
+        tag[key] = (tag[key] ?? 0) + 1;
+      }
+    }
+    final sorted = tag.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
     setState(() {
       dataList = [];
+      var colorIndex = 0;
+      for (final e in sorted) {
+        dataList.add(PieChartSectionData(
+          value: e.value.toDouble(),
+          title: e.key,
+          color: _pieColors[colorIndex % _pieColors.length],
+          titleStyle: const TextStyle(fontSize: 12, color: Colors.black),
+        ));
+        colorIndex++;
+      }
     });
   }
 

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -93,6 +93,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
   void _showAddContestDialog() async {
     // 提前获取 prefs，避免在 onPressed 的 async 回调里 await 后使用 context
     prefs = await SharedPreferences.getInstance();
+    if (!context.mounted) return;
     int startTime = 0, endTime = 0, startYMDseconds = 0, endYMDseconds = 0;
     int startHMseconds = 0, endHMseconds = 0;
     TextEditingController startTimeController = TextEditingController();

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -91,6 +91,8 @@ class _FavoritesPageState extends State<FavoritesPage> {
 
   //添加比赛界面
   void _showAddContestDialog() async {
+    // 提前获取 prefs，避免在 onPressed 的 async 回调里 await 后使用 context
+    prefs = await SharedPreferences.getInstance();
     int startTime = 0, endTime = 0, startYMDseconds = 0, endYMDseconds = 0;
     int startHMseconds = 0, endHMseconds = 0;
     TextEditingController startTimeController = TextEditingController();
@@ -356,7 +358,6 @@ class _FavoritesPageState extends State<FavoritesPage> {
           ),
           TextButton(
             onPressed: () async {
-              prefs = await SharedPreferences.getInstance();
               if (startYMDseconds == 0 || startHMseconds == 0) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -9,11 +9,13 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:day_night_time_picker/day_night_time_picker.dart';
 
 class FavoritesPage extends StatefulWidget {
+  const FavoritesPage({super.key});
+
   @override
-  State<FavoritesPage> createState() => _FavoritesPageState();
+  State<FavoritesPage> createState() => FavoritesPageState();
 }
 
-class _FavoritesPageState extends State<FavoritesPage> {
+class FavoritesPageState extends State<FavoritesPage> {
   final List<String> platforms = [
     '洛谷',
     '牛客',
@@ -24,8 +26,16 @@ class _FavoritesPageState extends State<FavoritesPage> {
   ];
   List<Contest> favoriteContests = [];
   late SharedPreferences prefs;
+
+  // 重新加载收藏列表（供导航切到本页时调用；IndexedStack 下页面常驻，
+  // initState 不会再次执行，需要主动刷新才能看到新收藏的/删除的比赛）
+  Future<void> reload() async {
+    favoriteContests.clear();
+    await __loadFavoriteContest();
+  }
+
   // 加载收藏夹
-  void __loadFavoriteContest() async {
+  Future<void> __loadFavoriteContest() async {
     prefs = await SharedPreferences.getInstance();
     final names = FavoriteUtils.getFavoriteNames(prefs);
     for (String s in names) {

--- a/lib/ui/favorites_page.dart
+++ b/lib/ui/favorites_page.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:oj_helper/models/contest.dart';
+import 'package:oj_helper/utils/favorite_utils.dart' show FavoriteUtils;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:day_night_time_picker/day_night_time_picker.dart';
@@ -24,23 +27,15 @@ class _FavoritesPageState extends State<FavoritesPage> {
   // 加载收藏夹
   void __loadFavoriteContest() async {
     prefs = await SharedPreferences.getInstance();
-    String? cur = prefs.getString('favourite_contests');
-    if (cur == null || cur == '') {
-      setState(() {});
-      return;
-    }
-    for (String s in cur.split(',')) {
+    final names = FavoriteUtils.getFavoriteNames(prefs);
+    for (String s in names) {
       if (s == '') continue;
-      String infor = prefs.getString(s) ?? '';
-      List<String> inforList = infor.split(',');
+      final infor = prefs.getString(s) ?? '';
       if (infor == '') continue;
-      favoriteContests.add(Contest.fromJson(
-        inforList[0],
-        int.parse(inforList[1]),
-        int.parse(inforList[2]),
-        inforList[3],
-        inforList[4],
-      ));
+      final contest = FavoriteUtils.parseStoredContest(infor);
+      if (contest != null) {
+        favoriteContests.add(contest);
+      }
     }
     favoriteContests
         .sort((a, b) => a.startTimeSeconds.compareTo(b.startTimeSeconds));
@@ -50,29 +45,11 @@ class _FavoritesPageState extends State<FavoritesPage> {
   // 删除比赛
   void _delFavoriteContest(Contest contest) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    String infor =
-        '${contest.name},${contest.startTimeSeconds},${contest.durationSeconds},${contest.platform},${contest.link}';
-    if (prefs.containsKey(contest.name)) {
+    final names = FavoriteUtils.getFavoriteNames(prefs);
+    if (names.contains(contest.name)) {
       await prefs.remove(contest.name);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        setState(() {});
-        return;
-      }
-      contestNames = cur.split(',');
-      contestNames.remove(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
-    } else {
-      await prefs.setString(contest.name, infor);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        setState(() {});
-        return;
-      }
-      contestNames.add(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
+      names.remove(contest.name);
+      await prefs.setString('favourite_contests', jsonEncode(names));
     }
     favoriteContests.remove(contest);
     setState(() {});
@@ -379,10 +356,18 @@ class _FavoritesPageState extends State<FavoritesPage> {
           ),
           TextButton(
             onPressed: () async {
-              if (startTime == 0 || endTime == 0) {
+              prefs = await SharedPreferences.getInstance();
+              if (startYMDseconds == 0 || startHMseconds == 0) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   const SnackBar(
-                    content: Text('请选择开始时间和结束时间'),
+                    content: Text('请完整选择开始时间（日期和时分）'),
+                  ),
+                );
+                return;
+              } else if (endYMDseconds == 0 || endHMseconds == 0) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('请完整选择结束时间（日期和时分）'),
                   ),
                 );
                 return;
@@ -412,18 +397,14 @@ class _FavoritesPageState extends State<FavoritesPage> {
                   return;
                 }
               }
-              String infor =
-                  '$name,$startTime,${endTime - startTime},$platform,$link';
-              await prefs.setString(name, infor);
-              String? cur = prefs.getString('favourite_contests');
-              List<String> contestNames = [];
-              if (cur == null) {
-                setState(() {});
-                return;
-              }
-              contestNames = cur.split(',');
+              await prefs.setString(
+                  name,
+                  FavoriteUtils.encodeContest(
+                      name, startTime, endTime - startTime, platform, link));
+              final contestNames = FavoriteUtils.getFavoriteNames(prefs);
               contestNames.add(name);
-              prefs.setString('favourite_contests', contestNames.join(','));
+              await prefs.setString(
+                  'favourite_contests', jsonEncode(contestNames));
               favoriteContests.add(Contest.fromJson(
                   name, startTime, endTime - startTime, platform, link));
               favoriteContests.sort(

--- a/lib/ui/navigation_page.dart
+++ b/lib/ui/navigation_page.dart
@@ -11,20 +11,36 @@ class NavigationPage extends StatefulWidget {
 }
 
 class _NavigationPageState extends State<NavigationPage> {
+  //当前选中项
+  int _selectedIndex = 0;
+  // 收藏页 key：IndexedStack 下页面常驻，切到收藏 tab 时需主动刷新
+  final GlobalKey<FavoritesPageState> _favoritesKey =
+      GlobalKey<FavoritesPageState>();
+  //页面列表（在 initState 中初始化，字段初始化器不能引用 this）
+  late final List<Widget> _pages;
+
   @override
   void initState() {
     super.initState();
+    _pages = [
+      RecentContestPage(),
+      FavoritesPage(key: _favoritesKey),
+      ServicePage(),
+      SettingPage(),
+    ];
   }
 
-  //当前选中项
-  int _selectedIndex = 0;
-  //页面列表
-  final List<Widget> _pages = [
-    RecentContestPage(),
-    FavoritesPage(),
-    ServicePage(),
-    SettingPage(),
-  ];
+  // 切换页面
+  void _onTabSelected(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+    // 切到收藏页时刷新收藏列表（近期比赛页可能刚收藏了新的比赛）
+    if (index == 1) {
+      _favoritesKey.currentState?.reload();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -44,11 +60,7 @@ class _NavigationPageState extends State<NavigationPage> {
                 children: [
                   NavigationRail(
                     selectedIndex: _selectedIndex,
-                    onDestinationSelected: (index) {
-                      setState(() {
-                        _selectedIndex = index;
-                      });
-                    },
+                    onDestinationSelected: _onTabSelected,
                     leading: SizedBox(height: 10),
                     labelType: NavigationRailLabelType.all,
                     destinations: const [
@@ -112,11 +124,7 @@ class _NavigationPageState extends State<NavigationPage> {
                     currentIndex: _selectedIndex,
                     selectedLabelStyle: TextStyle(color: Colors.blue),
                     // 点击事件
-                    onTap: (index) {
-                      setState(() {
-                        _selectedIndex = index;
-                      });
-                    },
+                    onTap: _onTabSelected,
                   ),
                 ],
               );

--- a/lib/ui/navigation_page.dart
+++ b/lib/ui/navigation_page.dart
@@ -70,18 +70,24 @@ class _NavigationPageState extends State<NavigationPage> {
                       ),
                     ],
                   ),
-                  // 页面内容
+                  // 页面内容（IndexedStack 保持各页面状态，切换不重建）
                   Expanded(
-                    child: _pages[_selectedIndex],
+                    child: IndexedStack(
+                      index: _selectedIndex,
+                      children: _pages,
+                    ),
                   ),
                 ],
               );
             } else {
               return Column(
                 children: [
-                  // 页面内容
+                  // 页面内容（IndexedStack 保持各页面状态，切换不重建）
                   Expanded(
-                    child: _pages[_selectedIndex],
+                    child: IndexedStack(
+                      index: _selectedIndex,
+                      children: _pages,
+                    ),
                   ),
                   // 底部导航栏
                   BottomNavigationBar(

--- a/lib/ui/rating_page.dart
+++ b/lib/ui/rating_page.dart
@@ -39,7 +39,9 @@ class _RatingPageState extends State<RatingPage> {
   Future<void> _loadPersistedData() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     for (var platformName in _platformNames) {
-      String? storedUsername = prefs.getString(platformName);
+      // 优先读新 key（rating_ 前缀），兼容旧版本直接用平台名作 key 的数据
+      String? storedUsername = prefs.getString('rating_$platformName') ??
+          prefs.getString(platformName);
       if (storedUsername != null) {
         _usernameControllers[platformName]!.text = storedUsername;
         setState(() {});
@@ -50,7 +52,7 @@ class _RatingPageState extends State<RatingPage> {
   // 保存用户输入的用户名
   Future<void> _saveUsername(String platformName, String username) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setString(platformName, username);
+    await prefs.setString('rating_$platformName', username);
   }
 
   // // 加载折线图(TODO)

--- a/lib/ui/recent_contest_page.dart
+++ b/lib/ui/recent_contest_page.dart
@@ -1,9 +1,11 @@
-import 'package:dio/dio.dart';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:oj_helper/models/contest.dart' show Contest;
 import 'package:oj_helper/provider.dart';
 import 'package:oj_helper/ui/widgets/dialog_checkbox.dart' show DialogCheckbox;
 import 'package:oj_helper/utils/contest_utils.dart' show ContestUtils;
+import 'package:oj_helper/utils/favorite_utils.dart' show FavoriteUtils;
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -21,7 +23,6 @@ class _RecentContestPageState extends State<RecentContestPage>
   bool get wantKeepAlive => true;
   final platForms = ['Codeforces', 'AtCoder', '洛谷', '蓝桥云课', '力扣', '牛客'];
   // 按日期分类的比赛列表，长度为7
-  Dio dio = Dio();
   // 查询天数，默认7天
   int day = 7;
   // 加载状态
@@ -36,53 +37,57 @@ class _RecentContestPageState extends State<RecentContestPage>
         isLoading = true;
       });
     }
-    ContestProvider contestProvider =
-        Provider.of<ContestProvider>(context, listen: false);
-    List<List<Contest>> nowContests = await ContestUtils.getRecentContests(
-        day: day, contestProvider: contestProvider);
-    contestProvider.setContests(nowContests);
-    if (mounted) {
-      setState(() {
-        isLoading = false;
-      });
+    try {
+      ContestProvider contestProvider =
+          Provider.of<ContestProvider>(context, listen: false);
+      List<List<Contest>> nowContests = await ContestUtils.getRecentContests(
+          day: day, contestProvider: contestProvider);
+      contestProvider.setContests(nowContests);
+    } catch (e) {
+      // 任一平台请求失败时给出提示，避免页面永久停留在加载中
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('加载比赛失败，请检查网络后重试')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          isLoading = false;
+        });
+      }
     }
   }
 
   //收藏比赛
   void _favoriteContest(Contest contest) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    String infor =
-        '${contest.name},${contest.startTimeSeconds},${contest.durationSeconds},${contest.platform},${contest.link}';
-    if (prefs.containsKey(contest.name)) {
+    List<String> contestNames = FavoriteUtils.getFavoriteNames(prefs);
+    if (contestNames.contains(contest.name)) {
       await prefs.remove(contest.name);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        prefs.setString('favourite_contests', '');
-        setState(() {});
-        return;
-      }
-      contestNames = cur.split(',');
       contestNames.remove(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
     } else {
-      await prefs.setString(contest.name, infor);
-      String? cur = prefs.getString('favourite_contests');
-      List<String> contestNames = [];
-      if (cur == null) {
-        prefs.setString('favourite_contests', '');
-        setState(() {});
-        return;
-      }
-      contestNames = cur.split(',');
+      await prefs.setString(
+          contest.name,
+          FavoriteUtils.encodeContest(contest.name, contest.startTimeSeconds,
+              contest.durationSeconds, contest.platform, contest.link));
       contestNames.add(contest.name);
-      prefs.setString('favourite_contests', contestNames.join(','));
     }
+    await prefs.setString('favourite_contests', jsonEncode(contestNames));
     setState(() {});
   }
 
   void _getSentences() async {
-    sentence = await sentenceServices.getSentences();
+    try {
+      final result = await sentenceServices.getSentences();
+      if (mounted) {
+        setState(() {
+          sentence = result;
+        });
+      }
+    } catch (e) {
+      // 网络失败时保持默认文案
+    }
   }
 
   void _wait() {
@@ -106,8 +111,18 @@ class _RecentContestPageState extends State<RecentContestPage>
   }
 
   @override
-  Widget build(BuildContext context) {
+  void initState() {
+    super.initState();
+    // 只在初始化时加载一次句子，避免 build 里反复发网络请求
     _getSentences();
+    // 初次进入页面自动加载近期比赛
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _loadContests();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     super.build(context);
     return Scaffold(
       appBar: AppBar(

--- a/lib/ui/setting_page.dart
+++ b/lib/ui/setting_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:oj_helper/utils/version_utils.dart' show VersionUtils;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -27,11 +28,6 @@ class _SettingPageState extends State<SettingPage> {
     });
   }
 
-  String _normalizeVersion(String version) {
-    // 移除 'v' 或 'V' 前缀，并移除所有点号
-    return version.replaceFirst(RegExp(r'^[vV]'), '').replaceAll('.', '');
-  }
-
   Future<void> checkForUpdate() async {
     setState(() {
       isChecking = true;
@@ -43,12 +39,9 @@ class _SettingPageState extends State<SettingPage> {
       if (response.statusCode == 200) {
         final latestRelease = json.decode(response.body);
         String latestVersion = latestRelease['tag_name'];
-        String releaseBody = latestRelease['body'];
+        String releaseBody = latestRelease['body'] ?? '';
 
-        String normalizedLatest = _normalizeVersion(latestVersion);
-        String normalizedCurrent = _normalizeVersion(curVersion);
-
-        if (normalizedLatest != normalizedCurrent) {
+        if (VersionUtils.isNewer(latestVersion, curVersion)) {
           _showUpdateDialog(curVersion, latestVersion, releaseBody);
         } else {
           _showNoUpdateDialog();

--- a/lib/ui/solvednum_page.dart
+++ b/lib/ui/solvednum_page.dart
@@ -67,7 +67,9 @@ class _SolvedNumPageState extends State<SolvedNumPage> {
   Future<void> _loadPersistedData() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     for (var platformName in _platformNames) {
-      String? storedUsername = prefs.getString(platformName);
+      // 优先读新 key（solved_ 前缀），兼容旧版本直接用平台名作 key 的数据
+      String? storedUsername = prefs.getString('solved_$platformName') ??
+          prefs.getString(platformName);
       if (storedUsername != null) {
         _usernameControllers[platformName]!.text = storedUsername;
         setState(() {});
@@ -78,7 +80,7 @@ class _SolvedNumPageState extends State<SolvedNumPage> {
   // 保存用户输入的用户名
   Future<void> _saveUsername(String platformName, String username) async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setString(platformName, username);
+    await prefs.setString('solved_$platformName', username);
   }
 
   //加载饼状图

--- a/lib/utils/contest_utils.dart
+++ b/lib/utils/contest_utils.dart
@@ -31,6 +31,8 @@ class ContestUtils {
     }
     // 开始时间排序
     recentContestsList.sort((a, b) => a.startTime.compareTo(b.startTime));
+    // 今天零点（本地），每次调用重新计算，避免跨天后 stale
+    final nowTime = _today;
     //按照开始的日期分组
     List<List<Contest>> timeContests = List.generate(7, (index) => <Contest>[]);
     for (Contest contest in recentContestsList) {
@@ -46,8 +48,6 @@ class ContestUtils {
   }
 
   static final DateFormat formatter = DateFormat('M月d日');
-  static final DateTime nowTime =
-      DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
   static final Map<int, String> weekdayMap = {
     1: '一',
     2: '二',
@@ -57,9 +57,17 @@ class ContestUtils {
     6: '六',
     0: '日',
   };
+
+  // 今天零点（本地），每次调用重新计算，避免跨天后 stale
+  static DateTime get _today {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day);
+  }
+
   //获取日期对应名称
   static String getDayName(int index) {
     if (index < 0 || index > 6) return '';
+    final nowTime = _today;
     if (index == 0) {
       return '今日   ${formatter.format(nowTime.add(Duration(days: index)))} 周${weekdayMap[nowTime.weekday % 7]}';
     } else if (index == 1) {

--- a/lib/utils/favorite_utils.dart
+++ b/lib/utils/favorite_utils.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:oj_helper/models/contest.dart' show Contest;
+import 'package:shared_preferences/shared_preferences.dart';
+
+///收藏数据的存储工具。
+///
+///统一使用 JSON 数组格式存储比赛信息和收藏名称列表，避免比赛名含逗号
+///时旧"逗号分隔"格式导致的字段错位/崩溃；同时兼容读取旧格式数据。
+class FavoriteUtils {
+  ///读取收藏名称列表，兼容旧格式（逗号分隔）
+  static List<String> getFavoriteNames(SharedPreferences prefs) {
+    final cur = prefs.getString('favourite_contests');
+    if (cur == null || cur.isEmpty) return [];
+    try {
+      final decoded = jsonDecode(cur);
+      if (decoded is List) {
+        return decoded.map((e) => e.toString()).toList();
+      }
+    } catch (_) {
+      // 旧格式，走逗号分隔
+    }
+    return cur.split(',').where((e) => e.isNotEmpty).toList();
+  }
+
+  ///序列化比赛为 JSON 存储串（不再用逗号分隔，避免名字中的逗号破坏数据）
+  static String encodeContest(
+    String name,
+    int startTimeSeconds,
+    int durationSeconds,
+    String platform,
+    String? link,
+  ) {
+    return jsonEncode([
+      name,
+      startTimeSeconds,
+      durationSeconds,
+      platform,
+      link,
+    ]);
+  }
+
+  ///从存储数据解析 Contest（兼容 JSON / 旧逗号两种格式），解析失败返回 null
+  static Contest? parseStoredContest(String infor) {
+    try {
+      final decoded = jsonDecode(infor);
+      if (decoded is List && decoded.length >= 4) {
+        final link = decoded.length > 4 &&
+                decoded[4] != null &&
+                decoded[4].toString().isNotEmpty
+            ? decoded[4].toString()
+            : null;
+        return Contest.fromJson(
+          decoded[0].toString(),
+          (decoded[1] as num).toInt(),
+          (decoded[2] as num).toInt(),
+          decoded[3].toString(),
+          link,
+        );
+      }
+    } catch (_) {
+      // 不是 JSON，走旧格式
+    }
+    // 兼容旧格式：逗号分隔
+    final inforList = infor.split(',');
+    if (inforList.length < 4) return null;
+    final start = int.tryParse(inforList[1]);
+    final duration = int.tryParse(inforList[2]);
+    if (start == null || duration == null) return null;
+    final link = inforList.length > 4 && inforList[4].isNotEmpty
+        ? inforList[4]
+        : null;
+    return Contest.fromJson(
+      inforList[0],
+      start,
+      duration,
+      inforList[3],
+      link,
+    );
+  }
+}

--- a/lib/utils/rating_utils.dart
+++ b/lib/utils/rating_utils.dart
@@ -10,7 +10,11 @@ class RatingUtils {
       case 'AtCoder':
         return await rs.getAtCoderRating(name: name);
       case '力扣':
-        return (await rs.getLeetCodeRating(name: name)).last;
+        final ratingList = await rs.getLeetCodeRating(name: name);
+        if (ratingList.isEmpty) {
+          throw Exception('该用户暂未参加力扣竞赛');
+        }
+        return ratingList.last;
       case '牛客':
         return await rs.getNowcoderRating(name: name);
       case '洛谷':

--- a/lib/utils/version_utils.dart
+++ b/lib/utils/version_utils.dart
@@ -1,0 +1,29 @@
+///语义化版本号比较工具（供设置页检查更新与单元测试使用）
+class VersionUtils {
+  /// 解析版本号 "v1.2.3" / "1.2.3+1" -> [1,2,3]，缺段补 0，忽略 "+build" 后缀
+  static List<int> parseVersion(String version) {
+    final cleaned = version.replaceFirst(RegExp(r'^[vV]'), '');
+    final parts = cleaned.split('.');
+    final result = <int>[];
+    for (final p in parts) {
+      result.add(int.tryParse(p.split('+').first.trim()) ?? 0);
+    }
+    while (result.length < 3) {
+      result.add(0);
+    }
+    return result;
+  }
+
+  /// latest 是否比 current 新（按段比较，避免 "2.0.0" < "1.10.0" 之类的字符串误判）
+  static bool isNewer(String latest, String current) {
+    final a = parseVersion(latest);
+    final b = parseVersion(current);
+    final len = a.length > b.length ? a.length : b.length;
+    for (var i = 0; i < len; i++) {
+      final av = i < a.length ? a[i] : 0;
+      final bv = i < b.length ? b[i] : 0;
+      if (av != bv) return av > bv;
+    }
+    return false;
+  }
+}

--- a/test/contest_test.dart
+++ b/test/contest_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:oj_helper/models/contest.dart';
+
+void main() {
+  group('Contest.fromJson', () {
+    test('格式化开始/结束时间、时长与链接', () {
+      // 本地时间 2024-06-29 20:00 对应的时间戳秒
+      final start = DateTime(2024, 6, 29, 20, 0).millisecondsSinceEpoch ~/ 1000;
+      final contest = Contest.fromJson(
+          '测试赛', start, 7200, 'AtCoder', 'https://example.com');
+
+      final fmt = DateFormat('yyyy-MM-dd HH:mm');
+      expect(contest.startTime, fmt.format(DateTime(2024, 6, 29, 20, 0)));
+      expect(contest.endTime, fmt.format(DateTime(2024, 6, 29, 22, 0)));
+      expect(contest.duration, '2 小时 0 分钟');
+      expect(contest.platform, 'AtCoder');
+      expect(contest.link, 'https://example.com');
+      expect(contest.startTimeSeconds, start);
+      expect(contest.durationSeconds, 7200);
+    });
+
+    test('跨天比赛结束时间正确', () {
+      // 23:00 开始，3 小时后结束（次日 02:00）
+      final start = DateTime(2024, 6, 29, 23, 0).millisecondsSinceEpoch ~/ 1000;
+      final contest = Contest.fromJson('深夜赛', start, 3 * 3600, '牛客', null);
+
+      final fmt = DateFormat('yyyy-MM-dd HH:mm');
+      expect(contest.startTime, fmt.format(DateTime(2024, 6, 29, 23, 0)));
+      expect(contest.endTime, fmt.format(DateTime(2024, 6, 30, 2, 0)));
+      expect(contest.duration, '3 小时 0 分钟');
+      expect(contest.link, isNull);
+    });
+  });
+}

--- a/test/favorite_utils_test.dart
+++ b/test/favorite_utils_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oj_helper/utils/favorite_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FavoriteUtils', () {
+    test('JSON 格式存储含逗号的比赛名不丢数据、可完整还原', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      const name = 'Codeforces Round 1, sponsored by X';
+      final encoded = FavoriteUtils.encodeContest(
+          name, 100, 7200, 'Codeforces', 'https://codeforces.com/contests');
+      await prefs.setString(name, encoded);
+      await prefs.setString('favourite_contests', '["$name"]');
+
+      expect(FavoriteUtils.getFavoriteNames(prefs), [name]);
+
+      final contest = FavoriteUtils.parseStoredContest(encoded);
+      expect(contest, isNotNull);
+      expect(contest!.name, name);
+      expect(contest.startTimeSeconds, 100);
+      expect(contest.durationSeconds, 7200);
+      expect(contest.platform, 'Codeforces');
+      expect(contest.link, 'https://codeforces.com/contests');
+    });
+
+    test('兼容旧逗号分隔格式', () {
+      final contest = FavoriteUtils.parseStoredContest('旧比赛,100,7200,牛客,https://x');
+      expect(contest, isNotNull);
+      expect(contest!.name, '旧比赛');
+      expect(contest.startTimeSeconds, 100);
+      expect(contest.link, 'https://x');
+    });
+
+    test('旧格式字段损坏时不崩溃，返回 null', () {
+      // 旧格式下名字含逗号会导致字段错位，必须安全跳过而不是崩溃
+      expect(FavoriteUtils.parseStoredContest('名字,含逗号,坏数据'), isNull);
+      expect(FavoriteUtils.parseStoredContest('只有名字'), isNull);
+    });
+
+    test('旧逗号分隔的收藏名列表兼容读取', () async {
+      SharedPreferences.setMockInitialValues({'favourite_contests': 'A,B,C'});
+      final prefs = await SharedPreferences.getInstance();
+      expect(FavoriteUtils.getFavoriteNames(prefs), ['A', 'B', 'C']);
+    });
+
+    test('空列表/空数据安全', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      expect(FavoriteUtils.getFavoriteNames(prefs), isEmpty);
+      expect(FavoriteUtils.parseStoredContest(''), isNull);
+    });
+  });
+}

--- a/test/favorites_page_test.dart
+++ b/test/favorites_page_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oj_helper/ui/favorites_page.dart';
+import 'package:oj_helper/utils/favorite_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('FavoritesPage.reload 能刷新出新收藏的比赛（IndexedStack 常驻场景）',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const MaterialApp(home: FavoritesPage()));
+    await tester.pump();
+
+    // 初始无收藏，页面不显示任何比赛
+    expect(find.text('测试比赛A'), findsNothing);
+
+    // 模拟在"近期比赛"页收藏了比赛（写入 SharedPreferences）
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        '测试比赛A',
+        FavoriteUtils.encodeContest(
+            '测试比赛A', 100, 7200, '牛客', 'https://ac.nowcoder.com'));
+    await prefs.setString('favourite_contests', '["测试比赛A"]');
+
+    // 切到收藏页时导航会调用 reload()
+    final state = tester.state<FavoritesPageState>(find.byType(FavoritesPage));
+    await state.reload();
+    await tester.pump();
+
+    // 新收藏的比赛应显示出来
+    expect(find.text('测试比赛A'), findsOneWidget);
+  });
+
+  testWidgets('FavoritesPage.reload 多次调用不重复添加', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const MaterialApp(home: FavoritesPage()));
+    await tester.pump();
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        '测试比赛B', FavoriteUtils.encodeContest('测试比赛B', 200, 3600, 'Codeforces', null));
+    await prefs.setString('favourite_contests', '["测试比赛B"]');
+
+    final state = tester.state<FavoritesPageState>(find.byType(FavoritesPage));
+    await state.reload();
+    await tester.pump();
+    await state.reload();
+    await tester.pump();
+
+    expect(find.text('测试比赛B'), findsOneWidget);
+  });
+}

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oj_helper/provider.dart';
+
+void main() {
+  group('ContestProvider.toggleShowEmptyDay', () {
+    test('按传入值设置状态而非简单取反（修复前忽略参数）', () {
+      final p = ContestProvider();
+      expect(p.showEmptyDay, isTrue);
+
+      // 传入 false 应关闭
+      p.toggleShowEmptyDay(false);
+      expect(p.showEmptyDay, isFalse);
+      // 再次传入 false 应保持关闭（旧实现取反会错误地重新打开）
+      p.toggleShowEmptyDay(false);
+      expect(p.showEmptyDay, isFalse);
+
+      p.toggleShowEmptyDay(true);
+      expect(p.showEmptyDay, isTrue);
+    });
+  });
+}

--- a/test/recent_contest_services_test.dart
+++ b/test/recent_contest_services_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(
         RecentContestServices.isInTime(
           startTime: midnight - 7200,
-          duration: 7200,
+          duration: 3600,
           queryEndSeconds: queryWindow,
           midnightSeconds: midnight,
         ),

--- a/test/recent_contest_services_test.dart
+++ b/test/recent_contest_services_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oj_helper/services/recent_contest_services.dart';
+
+void main() {
+  // 今天零点 = 1000（用假值测纯逻辑）
+  const midnight = 1000;
+  const queryWindow = 7 * 24 * 60 * 60;
+
+  group('RecentContestServices.isInTime', () {
+    test('进行中的比赛返回 0', () {
+      expect(
+        RecentContestServices.isInTime(
+          startTime: midnight - 100,
+          duration: 7200,
+          queryEndSeconds: queryWindow,
+          midnightSeconds: midnight,
+        ),
+        0,
+      );
+    });
+
+    test('开始过晚（超过 7 天窗口）返回 1', () {
+      expect(
+        RecentContestServices.isInTime(
+          startTime: midnight + queryWindow + 1,
+          duration: 7200,
+          queryEndSeconds: queryWindow,
+          midnightSeconds: midnight,
+        ),
+        1,
+      );
+    });
+
+    test('已结束（结束时刻早于今天零点）返回 2', () {
+      expect(
+        RecentContestServices.isInTime(
+          startTime: midnight - 7200,
+          duration: 7200,
+          queryEndSeconds: queryWindow,
+          midnightSeconds: midnight,
+        ),
+        2,
+      );
+    });
+
+    test('跨天进行中的长比赛（>24h）不被过滤（修复前会误返回 1）', () {
+      // 例如 AtCoder Heuristic 一周赛：今天零点开始、持续 7 天
+      expect(
+        RecentContestServices.isInTime(
+          startTime: midnight,
+          duration: 7 * 24 * 60 * 60,
+          queryEndSeconds: queryWindow,
+          midnightSeconds: midnight,
+        ),
+        0,
+      );
+    });
+
+    test('窗口边界：开始时间恰好在窗口内返回 0', () {
+      expect(
+        RecentContestServices.isInTime(
+          startTime: midnight + queryWindow,
+          duration: 3600,
+          queryEndSeconds: queryWindow,
+          midnightSeconds: midnight,
+        ),
+        0,
+      );
+    });
+  });
+}

--- a/test/version_utils_test.dart
+++ b/test/version_utils_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oj_helper/utils/version_utils.dart';
+
+void main() {
+  group('VersionUtils.parseVersion', () {
+    test('解析 v 前缀、缺段、build 后缀', () {
+      expect(VersionUtils.parseVersion('v1.2.3'), [1, 2, 3]);
+      expect(VersionUtils.parseVersion('2.9.4+1'), [2, 9, 4]);
+      expect(VersionUtils.parseVersion('1.2'), [1, 2, 0]);
+      expect(VersionUtils.parseVersion('v1'), [1, 0, 0]);
+    });
+  });
+
+  group('VersionUtils.isNewer', () {
+    test('正常版本递增', () {
+      expect(VersionUtils.isNewer('v2.9.4', 'v2.8.0'), isTrue);
+      expect(VersionUtils.isNewer('v1.2.3', 'v1.2.3'), isFalse);
+      expect(VersionUtils.isNewer('v1.2.2', 'v1.2.3'), isFalse);
+      expect(VersionUtils.isNewer('v1.2.3', 'v1.2.4'), isFalse);
+    });
+
+    test('跨主版本比较正确（旧实现字符串比较会误判 2.0.0 < 1.10.0）', () {
+      // 旧的 replaceAll('.','') 会把 1.10.0 变成 "1100"、2.0.0 变成 "200"，
+      // 导致"当前 2.0.0、最新 1.10.0"时错误提示降级更新
+      expect(VersionUtils.isNewer('v1.10.0', 'v2.0.0'), isFalse);
+      expect(VersionUtils.isNewer('v2.0.0', 'v1.10.0'), isTrue);
+    });
+
+    test('build 后缀与缺段', () {
+      expect(VersionUtils.isNewer('v1.2', 'v1.1.9'), isTrue);
+      expect(VersionUtils.isNewer('v1.2.3+1', 'v1.2.2'), isTrue);
+      expect(VersionUtils.isNewer('v1.2.3+1', 'v1.2.3'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 概述

1. **平台查询崩溃/卡死**：用户不存在、新账号暂无数据、接口返回异常等场景下，Codeforces / AtCoder / 力扣 / 洛谷 / 牛客 / VJudge / 码题集等查询会崩溃或页面永久转圈；收藏夹在比赛名含逗号时会解析错乱。
2. **近期比赛时间逻辑**：AtCoder 比赛时间显示早 1 小时；App 跨天运行后时间窗口判断失效；超过 24 小时的比赛被误过滤；牛客/蓝桥偶发解析失败拖垮整页。
3. **体验与正确性**：设置页版本比较误判（2.0.0 被判旧于 1.10.0）、底部导航切换丢状态、"收藏"页不刷新新收藏（回归）、"cf 分析"图表恒空。

## 修改范围（23 个文件，+803 / -212）

### 业务代码（16 个文件）

| 文件 | 改动 |
| --- | --- |
| `lib/services/rating_services.dart` | CF/AtCoder/洛谷/牛客查询崩溃防护、Dio 超时、保留调试入口 |
| `lib/services/solved_num_services.dart` | 力扣/洛谷/VJudge/ojhunt/码题集解析防护、Dio 超时、保留调试入口 |
| `lib/services/recent_contest_services.dart` | 时间窗口重构、AtCoder 时区修复、牛客/蓝桥容错、Dio 超时、保留调试入口 |
| `lib/services/report_services.dart` | CF `user.status` count 上限、Dio 超时 |
| `lib/services/sentence_services.dart` | Dio 超时 |
| `lib/utils/favorite_utils.dart`（新增） | 收藏 JSON 序列化/反序列化，兼容旧格式 |
| `lib/utils/version_utils.dart`（新增） | 语义化版本号解析与逐段比较 |
| `lib/utils/rating_utils.dart` | 力扣历史为空时抛可读异常 |
| `lib/utils/contest_utils.dart` | 日期分组基准时间不再 static 缓存 |
| `lib/ui/favorites_page.dart` | 收藏 JSON 存储、添加比赛时间校验、暴露 `reload()` |
| `lib/ui/recent_contest_page.dart` | 加载失败不再卡死、收藏逻辑 JSON 化、句子仅加载一次、进入自动加载 |
| `lib/ui/navigation_page.dart` | IndexedStack 保持页面状态、切到收藏 tab 主动刷新 |
| `lib/ui/rating_page.dart` | 本地存储 key 增加 `rating_` 前缀 |
| `lib/ui/solvednum_page.dart` | 本地存储 key 增加 `solved_` 前缀 |
| `lib/ui/setting_page.dart` | 检查更新改用 VersionUtils |
| `lib/ui/cf_report_page.dart` | 补全 tag 分布饼图、查询失败提示 |

### 单元测试（7 个文件，新增 6 个）

| 文件 | 覆盖内容 |
| --- | --- |
| `test/version_utils_test.dart`（新增） | 版本解析/比较（含 1.10 vs 2.0 误判场景） |
| `test/favorite_utils_test.dart`（新增） | 收藏 JSON/旧格式兼容、损坏数据安全 |
| `test/favorites_page_test.dart`（新增） | 收藏页 reload 刷新（IndexedStack 场景） |
| `test/recent_contest_services_test.dart`（新增） | 时间窗口边界（进行中/已结束/窗口/长比赛） |
| `test/contest_test.dart`（新增） | 比赛时间格式化（含跨天） |
| `test/provider_test.dart`（新增） | "显示无赛程日"开关状态 |
| `test/favorites_page_test.dart` 等 | 见上 |

## 改动明细

### 一、平台查询崩溃防护（rating_services.dart / solved_num_services.dart）

- **Codeforces rating**：原代码直接取 `result[0]['rating']`。用户不存在时 API 返回 `status=FAILED` 且 `result` 是错误字符串（按字符索引崩溃）；新账号 `rating` 为 `null` 时构造 `Rating(curRating: null)` 触发类型错误。改为：校验 `status == 'OK'` 且 `result` 非空，`rating`/`maxRating` 为 `null` 按 `0` 处理，否则抛"请求失败或用户不存在"。
- **AtCoder rating**：原代码 `getElementsByClassName('dl-table mt-2')[0]` 越界即崩；未参赛用户 rating 显示 `-`，`int.parse('-')` 抛 `FormatException`。改为：先检查表格存在与行数，rating 文本为 `-` 或空时抛"该用户暂无 rating"。
- **洛谷**：搜索无结果时 `users` 为空数组，`users[0]` 越界。改为：`users` 为空抛"未找到该洛谷用户"；elo 记录为空抛"暂无 rating 记录"。
- **力扣（题数）**：新用户 `numAcceptedQuestions` 可能为 `null`/空数组，原 `infor[0]` 越界且按 `[0][1][2]` 硬编码难度顺序。改为遍历数组累加 `count`，空数据返回 `0`。
- **牛客**：`rateHistory` 为空时 `.last` 越界、`rating` 为 `null` 时 `.toInt()` 崩溃。改为：空列表抛"暂无 rating 记录"，rating 用 `num` 安全转换。
- **VJudge / ojhunt（CF/HDU/牛客）**：`data` 或 `solved` 缺失时直接索引崩溃。统一改为缺失即抛"查询失败或用户不存在"。
- **码题集**：`error_no` 可能是数字或字符串（原 `== '0'` 在数字时永不匹配）；`datas`/`total` 可能 `null` 强转崩溃；用户不存在会无限翻页。改为 `toString()` 统一比较、`datas` 校验为 `List`、`total` 用 `num` 安全转换、昵称 `trim` 匹配、2000 页上限。
- **统一补充 Dio 超时**（connect 10s / receive 20s），避免接口挂起时永久 loading。

### 二、近期比赛时间逻辑（recent_contest_services.dart / contest_utils.dart）

- **`midnightSeconds` 跨天失效**：原为构造时一次性计算（`ms ~/ 1000 - hour * 3600`，还漏减分秒、边界偏差可达 1 小时），App 跨过午夜后判断全部失效。改为 `get` 属性每次实时计算本地零点。
- **`isInTime` 提取为公开静态方法**：原私有方法混入"时长 ≥ 24 小时即过滤"逻辑（AtCoder Heuristic 周赛等长比赛全被隐藏），已移除时长限制并拆出便于测试。
- **AtCoder 时间早 1 小时**：原 `DateFormat('...Z').parse(...).ms ~/ 1000 - 3600`，页面时间 `21:00:00+0900` 已含时区，`Z` 解析后已是绝对时刻，再减 3600 是双重转换。已删除 `- 3600` 并加注释。
- **牛客容错**：原假设每项必有 `<a>` 链接、必有 2 个时间文本（`matches.elementAt(1)`），异常条目直接 `StateError` 拖垮整页。改为缺失/不完整时 `continue` 跳过。
- **蓝桥容错**：原直接把 `response.data` 当数组遍历，接口若返回 `{data: [...]}` 包装则崩溃。改为兼容两种结构、跳过空字段条目。
- **`nowTime` 跨天**：原 `static final`（首次加载后永不更新），跨天后日期分组全错。改为每次调用动态计算。

### 三、收藏夹 JSON 化（favorite_utils.dart 新增 + favorites_page.dart / recent_contest_page.dart）

- **问题**：原用比赛名做 key、逗号分隔存字段（`名字,时间戳,时长,平台,链接`），名字含逗号时 `split(',')` 字段错位、`int.parse` 崩溃，导致收藏页打不开。
- **改法**：新增 `FavoriteUtils`，JSON 数组存储（`encodeContest` / `parseStoredContest` / `getFavoriteNames`），**兼容读取旧逗号格式**——旧数据正常迁移，损坏数据安全跳过（返回 null）。
- **添加比赛校验**：原只校验 `startTime == 0`，只选"时分"没选"日期"会存出 1970 年时间。改为分别校验日期与时分分量，缺一即提示"请完整选择时间"。

### 四、题数/分数页 key 隔离（solvednum_page.dart / rating_page.dart）

两页原共用 `平台名` 作 SharedPreferences key 互相覆盖用户名。分别使用 `solved_` / `rating_` 前缀，读取时回退旧 key 兼容老数据。

### 五、近期比赛页（recent_contest_page.dart）

- `_loadContests()` 原为 `async void` 无 try-catch，任一平台失败异常逃逸、`isLoading` 永久为 true。改为 try/catch/finally：失败弹 SnackBar，`isLoading` 必定复位。
- 诗词句子原在 `build()` 里每次重建都发请求且结果不刷新 UI，改为 `initState` 只加载一次并 `setState`。
- 进入页面自动加载近期比赛（原需手动点搜索按钮）。

### 六、版本比较（version_utils.dart 新增 + setting_page.dart）

- **问题**：原 `_normalizeVersion` 去点号成字符串（`2.0.0`→`"200"`、`1.10.0`→`"1100"`），字符串比较 `"200" < "1100"` 恒成立 → 当前 2.0.0、最新 1.10.0 会提示"降级更新"。
- **改法**：`VersionUtils.parseVersion` 按段解析为 `List<int>`（兼容 `v` 前缀、缺段补 0、忽略 `+build`），`isNewer` 逐段比较；`checkForUpdate` 只在真正更新时提示，并处理 `releaseBody` 为 null。

### 七、Tab 状态保持 + 收藏刷新回归（navigation_page.dart + favorites_page.dart）

- **状态保持**：原直接切换 `_pages[_selectedIndex]`，切走即 `dispose`、返回重新 `initState`（数据清空、重新请求）。改为 `IndexedStack`，各页 State 常驻。
- **回归修复**：IndexedStack 下 `FavoritesPage` 只 `initState` 一次，新收藏后切到"收藏"tab 不刷新。修复：`FavoritesPageState` 改为公开类型并新增 `reload()`；`NavigationPage` 用 `GlobalKey<FavoritesPageState>`，统一入口 `_onTabSelected` 切到收藏 tab 时调用 `reload()`。
- **实现细节**：`_pages` 改为 `late final` 在 `initState` 初始化（字段初始化器不能引用 `this`）。
- `_showAddContestDialog` 提前获取 `prefs` 并加 `context.mounted` 守卫，消除 async gap 隐患。

### 八、cf 分析图表（cf_report_page.dart + report_services.dart）

- 原 `_fetchData` 统计了 tag 但只执行 `dataList = []`，图表恒空且无异常处理。改为按 tag 统计、降序生成 `PieChartSectionData`（12 色循环），空用户名直接返回，查询失败弹 SnackBar。
- `user.status` 的 `count=1000000000` 超出 CF API 限制（约 1 万条），改为 `10000`。

## 单元测试（19 个用例，`flutter test` 全部通过）

- `VersionUtils`：正常递增、跨主版本（1.10 vs 2.0）、build 后缀、缺段。
- `FavoriteUtils`：含逗号比赛名 JSON 存取完整还原、旧逗号格式兼容、损坏数据返回 null、旧列表格式兼容。
- `FavoritesPage.reload`：模拟"比赛页收藏 → 切收藏页"场景，新收藏能显示；多次 reload 不重复（widget 测试）。
- `RecentContestServices.isInTime`：进行中 / 已结束 / 超出 7 天窗口 / 窗口边界 / 跨天 >24h 长比赛。
- `Contest.fromJson`：时间格式化、跨天结束时间、时长计算。
- `ContestProvider.toggleShowEmptyDay`：按传入值设置而非取反。

## 验证

- `flutter test`：19/19 通过
- `flutter analyze`：无 error
- `flutter build windows --release`：构建成功，安装包已在本机验证
